### PR TITLE
feat: updated to not require yaml for JVS client

### DIFF
--- a/client-lib/java/src/main/java/com/abcxyz/jvs/JVSClientBuilder.java
+++ b/client-lib/java/src/main/java/com/abcxyz/jvs/JVSClientBuilder.java
@@ -50,7 +50,7 @@ public class JVSClientBuilder {
   private static final int CACHE_SIZE = 10;
 
   @Getter(AccessLevel.PACKAGE)
-  JvsConfiguration configuration;
+  JvsConfiguration configuration = new JvsConfiguration();
 
   public JVSClientBuilder loadConfigFromFile(String fileName) throws IOException {
     try (InputStream input = getClass().getClassLoader().getResourceAsStream(fileName)) {
@@ -84,6 +84,16 @@ public class JVSClientBuilder {
 
   String getFromEnvironmentVars(String key) {
     return System.getenv().getOrDefault(key, null);
+  }
+
+  public JVSClientBuilder withJvsEndpoint(String jvsEndpoint) {
+    configuration.setJvsEndpoint(jvsEndpoint);
+    return this;
+  }
+
+  public JVSClientBuilder withCacheTimeout(Duration cacheTimeout) {
+    configuration.setCacheTimeout(cacheTimeout);
+    return this;
   }
 
   public JvsClient build() {

--- a/client-lib/java/src/main/java/com/abcxyz/jvs/JvsConfiguration.java
+++ b/client-lib/java/src/main/java/com/abcxyz/jvs/JvsConfiguration.java
@@ -31,14 +31,14 @@ public class JvsConfiguration {
 
   private static final String EXPECTED_VERSION = "1";
 
-  @JsonProperty(value = "version", defaultValue = EXPECTED_VERSION)
-  private String version;
+  @JsonProperty(value = "version")
+  private String version = EXPECTED_VERSION;
 
   @JsonProperty("endpoint")
-  private String jvsEndpoint;
+  private String jvsEndpoint = "localhost:8080";
 
   @JsonProperty("cache_timeout")
-  private Duration cacheTimeout;
+  private Duration cacheTimeout = Duration.ofMinutes(5);
 
   public void validate() throws IllegalArgumentException {
     if (!version.equals(EXPECTED_VERSION)) {

--- a/client-lib/java/src/test/java/com/abcxyz/jvs/JvsClientBuilderTest.java
+++ b/client-lib/java/src/test/java/com/abcxyz/jvs/JvsClientBuilderTest.java
@@ -71,13 +71,11 @@ public class JvsClientBuilderTest {
 
     JvsConfiguration expectedConfig = new JvsConfiguration();
     expectedConfig.setVersion("1");
+    expectedConfig.setJvsEndpoint("localhost:8080");
+    expectedConfig.setCacheTimeout(Duration.parse("PT5M"));
 
     JvsConfiguration loadedConfig = builder.getConfiguration();
     Assertions.assertEquals(expectedConfig, loadedConfig);
-    // values missing, expect exception.
-    IllegalArgumentException thrown =
-        Assertions.assertThrows(IllegalArgumentException.class, () -> loadedConfig.validate());
-    Assertions.assertTrue(thrown.getMessage().contains("JVS endpoint was not specified"));
 
     when(builder.getFromEnvironmentVars(JVSClientBuilder.ENDPOINT_ENV_KEY))
         .thenReturn("google.com");
@@ -155,11 +153,17 @@ public class JvsClientBuilderTest {
   }
 
   @Test()
-  public void testBuild_Fail() throws Exception {
+  public void testBuild_MissingValues() throws Exception {
     JVSClientBuilder builder = new JVSClientBuilder();
     builder.loadConfigFromFile("missing_values.yml");
-    IllegalArgumentException thrown =
-        Assertions.assertThrows(IllegalArgumentException.class, () -> builder.build());
-    Assertions.assertTrue(thrown.getMessage().contains("JVS endpoint was not specified"));
+
+    JvsConfiguration expectedConfig = new JvsConfiguration();
+    expectedConfig.setVersion("1");
+    expectedConfig.setJvsEndpoint("localhost:8080");
+    expectedConfig.setCacheTimeout(Duration.parse("PT5M"));
+
+    JvsConfiguration loadedConfig = builder.getConfiguration();
+    Assertions.assertEquals(expectedConfig, loadedConfig);
+    Assertions.assertDoesNotThrow(() -> loadedConfig.validate());
   }
 }


### PR DESCRIPTION
previously, the builder only allowed creating JVS clients using YAML. This changes so you can also specify through methods. It also adds the same defaults to the JVS client from the go code. 