### PR TITLE
fix: Modify JwkProviderBuilder call

### DIFF
--- a/client-lib/java/src/test/java/com/abcxyz/jvs/JvsClientBuilderTest.java
+++ b/client-lib/java/src/test/java/com/abcxyz/jvs/JvsClientBuilderTest.java
@@ -32,7 +32,7 @@ public class JvsClientBuilderTest {
 
     JvsConfiguration expectedConfig = new JvsConfiguration();
     expectedConfig.setVersion("1");
-    expectedConfig.setJvsEndpoint("example.com");
+    expectedConfig.setJvsEndpoint("http://example.com:8080");
     expectedConfig.setCacheTimeout(Duration.parse("PT5M"));
 
     JvsConfiguration loadedConfig = builder.getConfiguration();
@@ -123,7 +123,7 @@ public class JvsClientBuilderTest {
 
     JvsConfiguration expectedConfig = new JvsConfiguration();
     expectedConfig.setVersion("1");
-    expectedConfig.setJvsEndpoint("example.com");
+    expectedConfig.setJvsEndpoint("http://example.com:8080");
     expectedConfig.setCacheTimeout(Duration.parse("PT5M"));
 
     JvsConfiguration loadedConfig = builder.getConfiguration();

--- a/client-lib/java/src/test/resources/all_specified.yml
+++ b/client-lib/java/src/test/resources/all_specified.yml
@@ -1,3 +1,3 @@
 version: 1
-endpoint: example.com
+endpoint: http://example.com:8080
 cache_timeout: PT5M


### PR DESCRIPTION
if you pass in the string directly, it appends "/.well-known/jwks.json" on the end. This means that if we have the configuration the same as golang, we end up with the path "/.well-known/jwks/.well-known/jwks.json". This changes it to pass in a URL instead, which JwksProvider does not append a path on the end. see https://javadoc.io/doc/com.auth0/jwks-rsa/latest/com/auth0/jwk/JwkProviderBuilder.html