### PR TITLE
fix: use primary key version instead of latest key version to sign the token

### DIFF
--- a/pkg/idtoken/idtoken_test.go
+++ b/pkg/idtoken/idtoken_test.go
@@ -81,6 +81,7 @@ func TestIDTokenFromDefaultTokenSource(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ts := &tokenSource{tokenSource: tc.ts}
 			gotToken, err := ts.Token()
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {

--- a/pkg/idtoken/idtoken_test.go
+++ b/pkg/idtoken/idtoken_test.go
@@ -52,8 +52,6 @@ func (ts *fakeDefaultTokenSource) Token() (*oauth2.Token, error) {
 func TestIDTokenFromDefaultTokenSource(t *testing.T) {
 	t.Parallel()
 
-	now := time.Now()
-
 	tests := []struct {
 		name      string
 		ts        *fakeDefaultTokenSource
@@ -62,17 +60,17 @@ func TestIDTokenFromDefaultTokenSource(t *testing.T) {
 	}{{
 		name: "success",
 		ts: &fakeDefaultTokenSource{
-			expiry:  now,
+			expiry:  time.Now(),
 			idToken: "id-token",
 		},
 		wantToken: &oauth2.Token{
 			AccessToken: "id-token",
-			Expiry:      now,
+			Expiry:      time.Now(),
 		},
 	}, {
 		name: "error",
 		ts: &fakeDefaultTokenSource{
-			expiry:    now,
+			expiry:    time.Now(),
 			returnErr: fmt.Errorf("token err"),
 		},
 		wantErr: "token err",

--- a/pkg/idtoken/idtoken_test.go
+++ b/pkg/idtoken/idtoken_test.go
@@ -52,6 +52,8 @@ func (ts *fakeDefaultTokenSource) Token() (*oauth2.Token, error) {
 func TestIDTokenFromDefaultTokenSource(t *testing.T) {
 	t.Parallel()
 
+	now := time.Now()
+
 	tests := []struct {
 		name      string
 		ts        *fakeDefaultTokenSource
@@ -60,17 +62,17 @@ func TestIDTokenFromDefaultTokenSource(t *testing.T) {
 	}{{
 		name: "success",
 		ts: &fakeDefaultTokenSource{
-			expiry:  time.Now(),
+			expiry:  now,
 			idToken: "id-token",
 		},
 		wantToken: &oauth2.Token{
 			AccessToken: "id-token",
-			Expiry:      time.Now(),
+			Expiry:      now,
 		},
 	}, {
 		name: "error",
 		ts: &fakeDefaultTokenSource{
-			expiry:    time.Now(),
+			expiry:    now,
 			returnErr: fmt.Errorf("token err"),
 		},
 		wantErr: "token err",

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -158,7 +158,7 @@ func TestCreateToken(t *testing.T) {
 			}
 
 			mockKeyManagement.VersionName = version
-			mockKeyManagement.Labels["primary"] = "ver_" + "[VERSION]" + "-0"
+			mockKeyManagement.Labels[jvscrypto.PrimaryKey] = jvscrypto.PrimaryLabelPrefix + "[VERSION]" + "-0"
 
 			authKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 			if err != nil {

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -60,9 +60,6 @@ func TestCreateToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key := "projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[CRYPTO_KEY]"
-	version := key + "/cryptoKeyVersions/[VERSION]"
-	keyID := key + "/cryptoKeyVersions/[VERSION]-0"
 
 	tests := []struct {
 		name      string
@@ -108,6 +105,9 @@ func TestCreateToken(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			var clientOpt option.ClientOption
+			key := "projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[CRYPTO_KEY]"
+			version := key + "/cryptoKeyVersions/[VERSION]"
+			keyID := key + "/cryptoKeyVersions/[VERSION]-0"
 			mockKeyManagement := &testutil.MockKeyManagementServer{
 				UnimplementedKeyManagementServiceServer: kmspb.UnimplementedKeyManagementServiceServer{},
 				Reqs:                                    make([]proto.Message, 1),

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -63,6 +63,7 @@ func TestCreateToken(t *testing.T) {
 		Err:                                     nil,
 		Resps:                                   make([]proto.Message, 1),
 		NumVersions:                             1,
+		Labels:                                  make(map[string]string),
 	}
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -106,8 +107,9 @@ func TestCreateToken(t *testing.T) {
 	}
 
 	key := "projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[CRYPTO_KEY]"
-	version := key + "[VERSION]"
+	version := key + "/cryptoKeyVersions/[VERSION]"
 	mockKeyManagement.VersionName = version
+	mockKeyManagement.Labels["primary"] = "ver_" + "[VERSION]" + "-0"
 
 	authKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -53,11 +53,6 @@ func TestCreateToken(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	hour, err := time.ParseDuration("3600s")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	tests := []struct {
 		name      string
 		request   *jvspb.CreateJustificationRequest
@@ -73,13 +68,13 @@ func TestCreateToken(t *testing.T) {
 						Value:    "test",
 					},
 				},
-				Ttl: durationpb.New(hour),
+				Ttl: durationpb.New(3600 * time.Second),
 			},
 		},
 		{
 			name: "no_justification",
 			request: &jvspb.CreateJustificationRequest{
-				Ttl: durationpb.New(hour),
+				Ttl: durationpb.New(3600 * time.Second),
 			},
 			wantErr: "couldn't validate request",
 		},

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -51,7 +51,6 @@ func (j *MockJWTAuthHandler) RequestPrincipal(ctx context.Context) string {
 
 func TestCreateToken(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	tests := []struct {
 		name      string
@@ -96,6 +95,7 @@ func TestCreateToken(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := context.Background()
 			var clientOpt option.ClientOption
 			key := "projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[CRYPTO_KEY]"
 			version := key + "/cryptoKeyVersions/[VERSION]"

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -60,6 +60,10 @@ func TestCreateToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	key := "projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[CRYPTO_KEY]"
+	version := key + "/cryptoKeyVersions/[VERSION]"
+	keyID := key + "/cryptoKeyVersions/[VERSION]-0"
+
 	tests := []struct {
 		name      string
 		request   *jvspb.CreateJustificationRequest
@@ -153,8 +157,6 @@ func TestCreateToken(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			key := "projects/[PROJECT]/locations/[LOCATION]/keyRings/[KEY_RING]/cryptoKeys/[CRYPTO_KEY]"
-			version := key + "/cryptoKeyVersions/[VERSION]"
 			mockKeyManagement.VersionName = version
 			mockKeyManagement.Labels["primary"] = "ver_" + "[VERSION]" + "-0"
 
@@ -166,7 +168,7 @@ func TestCreateToken(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			keyID := key + "/cryptoKeyVersions/[VERSION]-0"
+
 			if err := ecdsaKey.Set(jwk.KeyIDKey, keyID); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -190,6 +190,7 @@ func TestCreateToken(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockKeyManagement.Reqs = nil
 			mockKeyManagement.Err = tc.serverErr
 

--- a/pkg/jvscrypto/cert_action_api.go
+++ b/pkg/jvscrypto/cert_action_api.go
@@ -54,7 +54,7 @@ func (p *CertificateActionService) certificateAction(ctx context.Context, reques
 			return fmt.Errorf("couldn't get key version %s: %w", action.Version, err)
 		}
 
-		primary, err := getPrimary(ctx, p.KMSClient, key)
+		primary, err := GetPrimary(ctx, p.KMSClient, key)
 		if err != nil {
 			return fmt.Errorf("couldn't determine current primary: %w", err)
 		}

--- a/pkg/jvscrypto/cert_action_api_test.go
+++ b/pkg/jvscrypto/cert_action_api_test.go
@@ -34,7 +34,6 @@ import (
 
 func TestCertificateAction(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	parent := fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", "[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
 	versionSuffix := "[VERSION]"
@@ -274,6 +273,7 @@ func TestCertificateAction(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := context.Background()
 			mockKMS := testutil.NewMockKeyManagementServer(parent, versionName, tc.priorPrimary)
 			mockKMS.Err = tc.serverErr
 

--- a/pkg/jvscrypto/cert_action_api_test.go
+++ b/pkg/jvscrypto/cert_action_api_test.go
@@ -273,6 +273,7 @@ func TestCertificateAction(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockKMS := testutil.NewMockKeyManagementServer(parent, versionName, tc.priorPrimary)
 			mockKMS.Err = tc.serverErr
 

--- a/pkg/jvscrypto/cert_action_api_test.go
+++ b/pkg/jvscrypto/cert_action_api_test.go
@@ -59,7 +59,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			priorPrimary: "ver_" + versionSuffix,
+			priorPrimary: PrimaryLabelPrefix + versionSuffix,
 			expectedRequests: []proto.Message{
 				&kmspb.CreateCryptoKeyVersionRequest{
 					Parent:           parent,
@@ -76,7 +76,7 @@ func TestCertificateAction(t *testing.T) {
 				},
 				&kmspb.UpdateCryptoKeyRequest{
 					CryptoKey: &kmspb.CryptoKey{
-						Labels: map[string]string{"primary": "ver_" + versionSuffix + "-new"},
+						Labels: map[string]string{PrimaryKey: PrimaryLabelPrefix + versionSuffix + "-new"},
 						Name:   parent,
 					},
 					UpdateMask: &fieldmaskpb.FieldMask{
@@ -84,7 +84,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			expectedPrimary: "ver_" + versionSuffix + "-new",
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix + "-new",
 			wantErr:         "",
 			serverErr:       nil,
 		},
@@ -98,7 +98,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			priorPrimary: "ver_" + versionSuffix,
+			priorPrimary: PrimaryLabelPrefix + versionSuffix,
 			expectedRequests: []proto.Message{
 				&kmspb.CreateCryptoKeyVersionRequest{
 					Parent:           parent,
@@ -115,7 +115,7 @@ func TestCertificateAction(t *testing.T) {
 				},
 				&kmspb.UpdateCryptoKeyRequest{
 					CryptoKey: &kmspb.CryptoKey{
-						Labels: map[string]string{"primary": "ver_" + versionSuffix + "-new"},
+						Labels: map[string]string{PrimaryKey: PrimaryLabelPrefix + versionSuffix + "-new"},
 						Name:   parent,
 					},
 					UpdateMask: &fieldmaskpb.FieldMask{
@@ -132,7 +132,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			expectedPrimary: "ver_" + versionSuffix + "-new",
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix + "-new",
 			wantErr:         "",
 			serverErr:       nil,
 		},
@@ -146,7 +146,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			priorPrimary: "ver_" + versionSuffix,
+			priorPrimary: PrimaryLabelPrefix + versionSuffix,
 			expectedRequests: []proto.Message{
 				&kmspb.GetCryptoKeyRequest{
 					Name: parent,
@@ -164,7 +164,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			expectedPrimary: "ver_" + versionSuffix,
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix,
 			wantErr:         "",
 			serverErr:       nil,
 		},
@@ -178,7 +178,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			priorPrimary: "ver_" + versionSuffix,
+			priorPrimary: PrimaryLabelPrefix + versionSuffix,
 			expectedRequests: []proto.Message{
 				&kmspb.CreateCryptoKeyVersionRequest{
 					Parent:           parent,
@@ -195,7 +195,7 @@ func TestCertificateAction(t *testing.T) {
 				},
 				&kmspb.UpdateCryptoKeyRequest{
 					CryptoKey: &kmspb.CryptoKey{
-						Labels: map[string]string{"primary": "ver_" + versionSuffix + "-new"},
+						Labels: map[string]string{PrimaryKey: PrimaryLabelPrefix + versionSuffix + "-new"},
 						Name:   parent,
 					},
 					UpdateMask: &fieldmaskpb.FieldMask{
@@ -206,7 +206,7 @@ func TestCertificateAction(t *testing.T) {
 					Name: versionName,
 				},
 			},
-			expectedPrimary: "ver_" + versionSuffix + "-new",
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix + "-new",
 			wantErr:         "",
 			serverErr:       nil,
 		},
@@ -224,7 +224,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			priorPrimary: "ver_" + versionSuffix,
+			priorPrimary: PrimaryLabelPrefix + versionSuffix,
 			expectedRequests: []proto.Message{
 				&kmspb.GetCryptoKeyRequest{
 					Name: parent,
@@ -256,7 +256,7 @@ func TestCertificateAction(t *testing.T) {
 				},
 				&kmspb.UpdateCryptoKeyRequest{
 					CryptoKey: &kmspb.CryptoKey{
-						Labels: map[string]string{"primary": "ver_" + versionSuffix + "-new"},
+						Labels: map[string]string{PrimaryKey: PrimaryLabelPrefix + versionSuffix + "-new"},
 						Name:   parent,
 					},
 					UpdateMask: &fieldmaskpb.FieldMask{
@@ -264,7 +264,7 @@ func TestCertificateAction(t *testing.T) {
 					},
 				},
 			},
-			expectedPrimary: "ver_" + versionSuffix + "-new",
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix + "-new",
 			wantErr:         "",
 			serverErr:       nil,
 		},

--- a/pkg/jvscrypto/key_hosting_test.go
+++ b/pkg/jvscrypto/key_hosting_test.go
@@ -63,7 +63,7 @@ func TestGenerateJWKString(t *testing.T) {
 	}{
 		{
 			name:    "happy-path",
-			primary: "ver_" + versionSuffix,
+			primary: PrimaryLabelPrefix + versionSuffix,
 			numKeys: 1,
 			wantOutput: fmt.Sprintf(`{"keys":[{"crv":"P-256","kid":"%s","kty":"EC","x":"%s","y":"%s"}]}`,
 				key+"/cryptoKeyVersions/[VERSION]-0",
@@ -72,7 +72,7 @@ func TestGenerateJWKString(t *testing.T) {
 		},
 		{
 			name:    "multi-key",
-			primary: "ver_" + versionSuffix,
+			primary: PrimaryLabelPrefix + versionSuffix,
 			numKeys: 2,
 			wantOutput: fmt.Sprintf(`{"keys":[{"crv":"P-256","kid":"%s","kty":"EC","x":"%s","y":"%s"},{"crv":"P-256","kid":"%s","kty":"EC","x":"%s","y":"%s"}]}`,
 				key+"/cryptoKeyVersions/[VERSION]-0",

--- a/pkg/jvscrypto/key_hosting_test.go
+++ b/pkg/jvscrypto/key_hosting_test.go
@@ -92,6 +92,7 @@ func TestGenerateJWKString(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockKMSServer := testutil.NewMockKeyManagementServer(key, key+"/cryptoKeyVersions/"+versionSuffix, tc.primary)
 			mockKMSServer.PrivateKey = privateKey
 			mockKMSServer.PublicKey = string(pemEncodedPub)

--- a/pkg/jvscrypto/key_hosting_test.go
+++ b/pkg/jvscrypto/key_hosting_test.go
@@ -39,7 +39,6 @@ import (
 
 func TestGenerateJWKString(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -93,6 +92,7 @@ func TestGenerateJWKString(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := context.Background()
 			mockKMSServer := testutil.NewMockKeyManagementServer(key, key+"/cryptoKeyVersions/"+versionSuffix, tc.primary)
 			mockKMSServer.PrivateKey = privateKey
 			mockKMSServer.PublicKey = string(pemEncodedPub)

--- a/pkg/jvscrypto/kmsutil.go
+++ b/pkg/jvscrypto/kmsutil.go
@@ -196,7 +196,8 @@ func GetPrimary(ctx context.Context, kms *kms.KeyManagementClient, key string) (
 
 // SetPrimary sets the key version name as primary in the key labels.
 // 'Primary' field will be omitted for keys with purpose other than ENCRYPT_DECRYPT(https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys).
-// Therefore, use `Labels` filed to set the primary key version name.
+// Therefore, use `Labels` filed to set the primary key version name with format `ver_[CRYPTO_KEY_Version_ID]`.
+// For example, "ver_1".
 func SetPrimary(ctx context.Context, kms *kms.KeyManagementClient, key, versionName string) error {
 	response, err := kms.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{Name: key})
 	if err != nil {

--- a/pkg/jvscrypto/kmsutil.go
+++ b/pkg/jvscrypto/kmsutil.go
@@ -180,8 +180,8 @@ func SignToken(token *jwt.Token, signer crypto.Signer) (string, error) {
 	return strings.Join([]string{signingString, jwt.EncodeSegment(sig)}, "."), nil
 }
 
-// getPrimary gets the key version name marked as primary in the key labels.
-func getPrimary(ctx context.Context, kms *kms.KeyManagementClient, key string) (string, error) {
+// GetPrimary gets the key version name marked as primary in the key labels.
+func GetPrimary(ctx context.Context, kms *kms.KeyManagementClient, key string) (string, error) {
 	response, err := kms.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{Name: key})
 	if err != nil {
 		return "", fmt.Errorf("issue while getting key from KMS: %w", err)

--- a/pkg/jvscrypto/rotation_handler.go
+++ b/pkg/jvscrypto/rotation_handler.go
@@ -64,7 +64,7 @@ func (h *RotationHandler) RotateKey(ctx context.Context, key string) error {
 	}
 
 	// Get any relevant Key Version information from the StateStore
-	primaryName, err := getPrimary(ctx, h.KMSClient, key)
+	primaryName, err := GetPrimary(ctx, h.KMSClient, key)
 	if err != nil {
 		return fmt.Errorf("unable to determine primary: %w", err)
 	}

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -320,7 +320,7 @@ func TestPerformActions(t *testing.T) {
 					},
 				},
 			},
-			expectedPrimary: "ver_" + versionSuffix + "-new",
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix + "-new",
 		},
 		{
 			name: "destroy",
@@ -352,8 +352,8 @@ func TestPerformActions(t *testing.T) {
 					},
 				},
 			},
-			priorPrimary:    "ver_" + versionSuffix,
-			expectedPrimary: "ver_" + versionSuffix,
+			priorPrimary:    PrimaryLabelPrefix + versionSuffix,
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix,
 			wantErr:         "",
 			expectedRequests: []proto.Message{
 				&kmspb.CreateCryptoKeyVersionRequest{

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -91,7 +91,6 @@ func TestGetKeyNameFromVersion(t *testing.T) {
 }
 
 func TestDetermineActions(t *testing.T) {
-	ctx := context.Background()
 	t.Parallel()
 
 	keyTTL, err := time.ParseDuration("240h") // 10 days
@@ -228,6 +227,7 @@ func TestDetermineActions(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := context.Background()
 			output, err := handler.determineActions(ctx, tc.versions, tc.primary, curTime)
 
 			if diff := cmp.Diff(tc.wantActions, output, protocmp.Transform()); diff != "" {
@@ -251,7 +251,6 @@ func TestDetermineActions(t *testing.T) {
 
 func TestPerformActions(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	parent := fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", "[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
 	versionSuffix := "[VERSION]"
@@ -390,6 +389,7 @@ func TestPerformActions(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := context.Background()
 			mockKeyManagement := testutil.NewMockKeyManagementServer(parent, versionName, tc.priorPrimary)
 			mockKeyManagement.Err = tc.serverErr
 			mockKeyManagement.Resps = append(mockKeyManagement.Resps[:0], &kmspb.CryptoKeyVersion{Name: versionName + "-new"})

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -389,6 +389,7 @@ func TestPerformActions(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mockKeyManagement := testutil.NewMockKeyManagementServer(parent, versionName, tc.priorPrimary)
 			mockKeyManagement.Err = tc.serverErr
 			mockKeyManagement.Resps = append(mockKeyManagement.Resps[:0], &kmspb.CryptoKeyVersion{Name: versionName + "-new"})

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -889,7 +889,7 @@ func testValidatePublicKeys(ctx context.Context, tb testing.TB, ks *jvscrypto.Ke
 ) {
 	tb.Helper()
 
-	req, err := http.NewRequest("GET", "/.well-known/jwks", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", "/.well-known/jwks", nil)
 	if err != nil {
 		tb.Fatalf("http.NewRequest(): got %v, want no error", err)
 	}

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -245,6 +245,7 @@ func TestJVS(t *testing.T) {
 	}
 }
 
+//nolint:tparallel // subtests need to run in sequence.
 func TestRotator(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -338,6 +339,7 @@ func TestRotator(t *testing.T) {
 	})
 }
 
+//nolint:tparallel // subtests need to run in sequence.
 func TestRotator_EdgeCases(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -463,6 +465,7 @@ func TestPublicKeys(t *testing.T) {
 	})
 }
 
+//nolint:tparallel // subtests need to run in sequence.
 func TestCertActions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -339,7 +339,7 @@ func TestRotator(t *testing.T) {
 }
 
 //nolint:tparallel
-// Subtests need to run in sequence. To parallelize this, but we'd need separate keys from the above (more cruft)
+// Subtests need to run in sequence. To parallelize this, but we'd need separate keys from the above (more cruft).
 func TestRotator_EdgeCases(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
fix #106 
1. use primary key version instead of latest key version to sign the token 
2. fix main brnach lint error(ran into multiple lint errors from main branch)
