### PR TITLE
Don't use a pointer to an interface

### DIFF
--- a/client-lib/go/client/jvs_client.go
+++ b/client-lib/go/client/jvs_client.go
@@ -64,7 +64,7 @@ func NewJVSClient(ctx context.Context, config *JVSConfig) (*JVSClient, error) {
 }
 
 // ValidateJWT takes a jwt string, converts it to a JWT, and validates the signature.
-func (j *JVSClient) ValidateJWT(jwtStr string) (*jwt.Token, error) {
+func (j *JVSClient) ValidateJWT(jwtStr string) (jwt.Token, error) {
 	// Handle unsigned tokens.
 	if strings.HasSuffix(jwtStr, UnsignedPostfix) {
 		token, err := jwt.Parse([]byte(jwtStr), jwt.WithVerify(false))
@@ -74,7 +74,7 @@ func (j *JVSClient) ValidateJWT(jwtStr string) (*jwt.Token, error) {
 		if err := j.unsignedTokenValidAndAllowed(token); err != nil {
 			return nil, fmt.Errorf("token unsigned and could not be validated: %w", err)
 		}
-		return &token, nil
+		return token, nil
 	}
 	return jvscrypto.ValidateJWT(j.keys, jwtStr)
 }

--- a/pkg/jvscrypto/kmsutil.go
+++ b/pkg/jvscrypto/kmsutil.go
@@ -240,13 +240,13 @@ func getLabelValue(versionName string) (string, error) {
 }
 
 // ValidateJWT takes a jwt string, converts it to a JWT, and validates the signature.
-func ValidateJWT(keySet jwk.Set, jwtStr string) (*jwt2.Token, error) {
+func ValidateJWT(keySet jwk.Set, jwtStr string) (jwt2.Token, error) {
 	verifiedToken, err := jwt2.Parse([]byte(jwtStr), jwt2.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify jwt %s: %w", jwtStr, err)
 	}
 
-	return &verifiedToken, nil
+	return verifiedToken, nil
 }
 
 // JWKList creates a list of public keys in JWK format.

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -224,7 +224,7 @@ func TestJVS(t *testing.T) {
 				return
 			}
 
-			tokenMap, err := (*token).AsMap(ctx)
+			tokenMap, err := token.AsMap(ctx)
 			if err != nil {
 				t.Errorf("Couldn't convert token to map: %v", err)
 				return


### PR DESCRIPTION
This is part of a cleanup for https://github.com/abcxyz/jvs/issues/116. In golang-jwt, Token is a struct. In jwx, it's an interface. Returning a pointer to an interface is generally frowned upon. This changes the interface to always be returned as an interface, but there needs to be a larger effort around reducing to a single jwt library.