### PR TITLE
Remove JVS_ prefix from public configuration

### DIFF
--- a/client-lib/go/client/jvs_config.go
+++ b/client-lib/go/client/jvs_config.go
@@ -72,8 +72,7 @@ func loadJVSConfigFromLookuper(ctx context.Context, b []byte, lookuper envconfig
 	}
 
 	// Process overrides from env vars.
-	l := envconfig.PrefixLookuper("JVS_", lookuper)
-	if err := envconfig.ProcessWith(ctx, cfg, l); err != nil {
+	if err := envconfig.ProcessWith(ctx, cfg, lookuper); err != nil {
 		return nil, err
 	}
 

--- a/client-lib/go/client/jvs_config_test.go
+++ b/client-lib/go/client/jvs_config_test.go
@@ -94,10 +94,10 @@ cache_timeout: 1m
 allow_breakglass: false
 `,
 			envs: map[string]string{
-				"JVS_VERSION":          "1",
-				"JVS_ENDPOINT":         "other.net:443",
-				"JVS_CACHE_TIMEOUT":    "2m",
-				"JVS_ALLOW_BREAKGLASS": "true",
+				"VERSION":          "1",
+				"ENDPOINT":         "other.net:443",
+				"CACHE_TIMEOUT":    "2m",
+				"ALLOW_BREAKGLASS": "true",
 			},
 			wantConfig: &JVSConfig{
 				Version:         "1",

--- a/client-lib/java/src/main/java/com/abcxyz/jvs/JVSClientBuilder.java
+++ b/client-lib/java/src/main/java/com/abcxyz/jvs/JVSClientBuilder.java
@@ -37,18 +37,18 @@ import lombok.Getter;
  * environment variables. Set environment variables are automatically loaded when build() is called.
  * If a yaml and environment variable are both set, the env variable is used.
  *
- * <p>env: JVS_VERSION yaml: version. Specifies the version of the configuration.
+ * <p>env: VERSION yaml: version. Specifies the version of the configuration.
  *
- * <p>env: JVS_CACHE_TIMEOUT yaml: cache_timeout. Specifies how long until cached public keys are
+ * <p>env: CACHE_TIMEOUT yaml: cache_timeout. Specifies how long until cached public keys are
  * invalidated.
  *
- * <p>env: JVS_ENDPOINT yaml: endpoint. Specifies the url for retrieving public keys.
+ * <p>env: ENDPOINT yaml: endpoint. Specifies the url for retrieving public keys.
  */
 public class JVSClientBuilder {
 
-  static final String ENDPOINT_ENV_KEY = "JVS_ENDPOINT";
-  static final String CACHE_TIMEOUT_ENV_KEY = "JVS_CACHE_TIMEOUT";
-  static final String VERSION_ENV_KEY = "JVS_VERSION";
+  static final String ENDPOINT_ENV_KEY = "ENDPOINT";
+  static final String CACHE_TIMEOUT_ENV_KEY = "CACHE_TIMEOUT";
+  static final String VERSION_ENV_KEY = "VERSION";
   private static final int CACHE_SIZE = 10;
 
   @Getter(AccessLevel.PACKAGE)

--- a/docs/jvs-quick-setup.md
+++ b/docs/jvs-quick-setup.md
@@ -76,13 +76,13 @@ will also get created.
     Terraform outputs like `jvs-e2e-xxxx-uc.a.run.app`
 
     ```shell
-    export JVS_SERVER=<jvs_server_domain>:443
+    export SERVER=<jvs_server_domain>:443
     ```
 
 2.  Create Justification Token via [jvsctl](cli-tool.md):
 
     ```shell
-    jvsctl token --explanation "issues/12345" --ttl 30m --server ${JVS_SERVER}
+    jvsctl token --explanation "issues/12345" --ttl 30m --server ${SERVER}
     ```
 
 **TODO(#112):** Once we have the "validate token" command, we can even validate

--- a/pkg/config/crypto_config.go
+++ b/pkg/config/crypto_config.go
@@ -106,8 +106,7 @@ func loadCryptoConfigFromLookuper(ctx context.Context, b []byte, lookuper envcon
 	}
 
 	// Process overrides from env vars.
-	l := envconfig.PrefixLookuper("JVS_", lookuper)
-	if err := envconfig.ProcessWith(ctx, cfg, l); err != nil {
+	if err := envconfig.ProcessWith(ctx, cfg, lookuper); err != nil {
 		return nil, fmt.Errorf("failed to process environment: %w", err)
 	}
 

--- a/pkg/config/crypto_config_test.go
+++ b/pkg/config/crypto_config_test.go
@@ -173,8 +173,8 @@ disabled_period: 720h # 30 days
 propagation_delay: 1h
 `,
 			envs: map[string]string{
-				"JVS_KEY_TTL":      "1080h", // 45 days
-				"JVS_GRACE_PERIOD": "4h",
+				"KEY_TTL":      "1080h", // 45 days
+				"GRACE_PERIOD": "4h",
 			},
 			wantConfig: &CryptoConfig{
 				Version:          "1",
@@ -188,10 +188,10 @@ propagation_delay: 1h
 			name: "non_default_values_specified_in_envs",
 			cfg:  ``,
 			envs: map[string]string{
-				"JVS_KEY_TTL":           "1080h", // 45 days
-				"JVS_GRACE_PERIOD":      "4h",
-				"JVS_DISABLED_PERIOD":   "1080h", // 45 days
-				"JVS_PROPAGATION_DELAY": "1h",
+				"KEY_TTL":           "1080h", // 45 days
+				"GRACE_PERIOD":      "4h",
+				"DISABLED_PERIOD":   "1080h", // 45 days
+				"PROPAGATION_DELAY": "1h",
 			},
 			wantConfig: &CryptoConfig{
 				Version:          "1",

--- a/pkg/config/justification_config.go
+++ b/pkg/config/justification_config.go
@@ -77,8 +77,7 @@ func loadJustificationConfigFromLookuper(ctx context.Context, b []byte, lookuper
 	}
 
 	// Process overrides from env vars.
-	l := envconfig.PrefixLookuper("JVS_", lookuper)
-	if err := envconfig.ProcessWith(ctx, cfg, l); err != nil {
+	if err := envconfig.ProcessWith(ctx, cfg, lookuper); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/justification_config_test.go
+++ b/pkg/config/justification_config_test.go
@@ -108,10 +108,10 @@ signer_cache_timeout: 1m
 issuer: jvs
 `,
 			envs: map[string]string{
-				"JVS_VERSION":              "1",
-				"JVS_PORT":                 "tcp",
-				"JVS_SIGNER_CACHE_TIMEOUT": "2m",
-				"JVS_ISSUER":               "other",
+				"VERSION":              "1",
+				"PORT":                 "tcp",
+				"SIGNER_CACHE_TIMEOUT": "2m",
+				"ISSUER":               "other",
 			},
 			wantConfig: &JustificationConfig{
 				Version:            "1",

--- a/terraform/modules/cert-action-service/main.tf
+++ b/terraform/modules/cert-action-service/main.tf
@@ -71,23 +71,23 @@ resource "google_cloud_run_service" "cert-action" {
           }
         }
         env {
-          name  = "JVS_KEY_NAMES"
+          name  = "KEY_NAMES"
           value = var.key_id
         }
         env {
-          name  = "JVS_KEY_TTL"
+          name  = "KEY_TTL"
           value = var.key_ttl
         }
         env {
-          name  = "JVS_GRACE_PERIOD"
+          name  = "GRACE_PERIOD"
           value = var.key_grace_period
         }
         env {
-          name  = "JVS_DISABLED_PERIOD"
+          name  = "DISABLED_PERIOD"
           value = var.key_disabled_period
         }
         env {
-          name  = "JVS_PROPAGATION_DELAY"
+          name  = "PROPAGATION_DELAY"
           value = var.key_propagation_delay
         }
       }

--- a/terraform/modules/cert-rotator/main.tf
+++ b/terraform/modules/cert-rotator/main.tf
@@ -72,23 +72,23 @@ resource "google_cloud_run_service" "cert-rotator" {
           }
         }
         env {
-          name  = "JVS_KEY_NAMES"
+          name  = "KEY_NAMES"
           value = var.key_id
         }
         env {
-          name  = "JVS_KEY_TTL"
+          name  = "KEY_TTL"
           value = var.key_ttl
         }
         env {
-          name  = "JVS_GRACE_PERIOD"
+          name  = "GRACE_PERIOD"
           value = var.key_grace_period
         }
         env {
-          name  = "JVS_DISABLED_PERIOD"
+          name  = "DISABLED_PERIOD"
           value = var.key_disabled_period
         }
         env {
-          name  = "JVS_PROPAGATION_DELAY"
+          name  = "PROPAGATION_DELAY"
           value = var.key_propagation_delay
         }
       }

--- a/terraform/modules/jvs-service/main.tf
+++ b/terraform/modules/jvs-service/main.tf
@@ -71,7 +71,7 @@ resource "google_cloud_run_service" "server" {
           }
         }
         env {
-          name  = "JVS_KEY"
+          name  = "KEY"
           value = var.key_id
         }
       }


### PR DESCRIPTION
The tests still use TEST_JVS_* to prevent accidentally running the tests against the wrong envvars.

Closes https://github.com/abcxyz/jvs/issues/124