### PR TITLE
Drop global variables in CLI

### DIFF
--- a/cmd/jvsctl/main.go
+++ b/cmd/jvsctl/main.go
@@ -15,13 +15,20 @@
 package main
 
 import (
-	"log"
+	"context"
+	"os/signal"
+	"syscall"
 
 	"github.com/abcxyz/jvs/pkg/cli"
+	"github.com/abcxyz/pkg/logging"
 )
 
 func main() {
-	if err := cli.Execute(); err != nil {
-		log.Fatalln(err)
-	}
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer done()
+
+	logger := logging.NewFromEnv("")
+	ctx = logging.WithLogger(ctx, logger)
+
+	cli.Execute(ctx)
 }

--- a/docs/cli-tool.md
+++ b/docs/cli-tool.md
@@ -25,7 +25,7 @@ Minimally we need a JVS server address in the config to mint justification
 tokens.
 
 ```yaml
-server: example.com
+server: example.com:4567
 ```
 
 By default, we will connect to the JVS server securely. When it's not applicable
@@ -33,8 +33,7 @@ By default, we will connect to the JVS server securely. When it's not applicable
 following block in the config:
 
 ```yaml
-authentication:
-  insecure: true
+insecure: true
 ```
 
 Alternatively, both of these values could be provided via CLI flags `--server`
@@ -61,7 +60,7 @@ duration and such token provide reasons that data access is required for
 "issues/12345"
 
 ```shell
-jvsctl token --breakglass true --explanation "jvs is down" --ttl 30m
+jvsctl token --breakglass --explanation "jvs is down" --ttl 30m
 ```
 
 In certain cases, we might need to bypass JVS for minting signed JVS tokens.

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,54 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cli implements the commands for the JVS CLI.
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/abcxyz/jvs/pkg/config"
+)
+
+const (
+	// Issuer is the default issuer (iss) for tokens created by the CLI.
+	Issuer = "jvsctl"
+
+	// Subject is the default subject (sub) for tokens created by the CLI.
+	Subject = "jvsctl"
+)
+
+// defaultConfigPath is the path on disk for the default configuration.
+var defaultConfigPath = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".jvsctl", "config.yaml")
+}()
+
+// Execute executes the CLI.
+func Execute(ctx context.Context) {
+	var cfg config.CLIConfig
+
+	cmd := newRootCmd(&cfg)
+	if err := cmd.Execute(); err != nil {
+		stderr := cmd.ErrOrStderr()
+		fmt.Fprintln(stderr, err.Error())
+		os.Exit(1)
+	}
+}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -15,36 +15,127 @@
 package cli
 
 import (
-	"io/fs"
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/cobra"
 )
 
-func TestInitCfg(t *testing.T) {
-	cfgFile = filepath.Join(t.TempDir(), ".jvsctl.yaml")
+func TestNewRootCmd(t *testing.T) {
+	t.Parallel()
 
-	if err := os.WriteFile(cfgFile, []byte(`server: https://example.com
-`), fs.ModePerm); err != nil {
-		t.Fatalf("failed to prepare test config file: %v", err)
+	configFile := filepath.Join(t.TempDir(), ".jvsctl.yaml")
+	if err := os.WriteFile(configFile, []byte(strings.TrimSpace(`
+server: 1.2.3.4:5678
+insecure: true
+	`)), 0o600); err != nil {
+		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		if err := os.Remove(cfgFile); err != nil {
-			t.Logf("failed to cleanup test config file: %v", err)
+		if err := os.Remove(configFile); err != nil {
+			t.Error(err)
 		}
 	})
 
-	initCfg()
+	cases := []struct {
+		name      string
+		args      []string
+		expConfig *config.CLIConfig
+	}{
+		{
+			name: "default_config",
+			expConfig: &config.CLIConfig{
+				Version: "1",
+				Server:  "127.0.0.1:8080",
+			},
+		},
+		{
+			name: "flag_config",
+			args: []string{"--config", configFile},
+			expConfig: &config.CLIConfig{
+				Version:  "1",
+				Server:   "1.2.3.4:5678",
+				Insecure: true,
+			},
+		},
+		{
+			name: "flag_server",
+			args: []string{"--server", "1.2.3.4:5678"},
+			expConfig: &config.CLIConfig{
+				Version: "1",
+				Server:  "1.2.3.4:5678",
+			},
+		},
+		{
+			name: "flag_insecure",
+			args: []string{"--insecure"},
+			expConfig: &config.CLIConfig{
+				Version:  "1",
+				Server:   "127.0.0.1:8080",
+				Insecure: true,
+			},
+		},
+	}
 
-	wantCfg := &config.CLIConfig{
-		Version:        "1",
-		Server:         "https://example.com",
-		Authentication: &config.CLIAuthentication{},
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg config.CLIConfig
+			cmd := newRootCmd(&cfg)
+
+			// Add a fake subcommand to invoke for testing. This is required because
+			// the pre/post hooks do not fire on root commands.
+			cmd.AddCommand(&cobra.Command{
+				Use: "testing",
+				Run: func(cmd *cobra.Command, args []string) {},
+			})
+
+			args := append([]string{"testing"}, tc.args...)
+			if _, _, err := testExecuteCommand(t, cmd, args...); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expConfig, &cfg); diff != "" {
+				t.Errorf("config (-want, +got):\n%s", diff)
+			}
+		})
 	}
-	if diff := cmp.Diff(wantCfg, cfg); diff != "" {
-		t.Errorf("CLI config loaded (-want,+got):\n%s", diff)
-	}
+}
+
+// testExecteCommand executes the given cobra command and returns the stdout,
+// stderr, and any execution error. See [testExecuteCommandStdin] for more
+// information.
+func testExecuteCommand(tb testing.TB, cmd *cobra.Command, args ...string) (string, string, error) {
+	tb.Helper()
+	return testExecuteCommandStdin(tb, cmd, nil, args...)
+}
+
+// testExecuteCommandStdin executes the given cobra command with the stdin
+// writer w and returns the stdout, stderr, and any errors that occur during
+// execution. It is safe for concurrent use if and only if the cobra command is
+// safe for concurrent use (e.g. does not read or set global state). The
+// convenience function [testExecuteCommand] exists for calling without stdin.
+func testExecuteCommandStdin(tb testing.TB, cmd *cobra.Command, stdin io.Reader, args ...string) (string, string, error) {
+	tb.Helper()
+
+	var stdout, stderr bytes.Buffer
+	defer stdout.Reset()
+	defer stderr.Reset()
+
+	cmd.SetIn(stdin)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
 }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -120,7 +120,7 @@ func testExecuteCommand(tb testing.TB, cmd *cobra.Command, args ...string) (stri
 }
 
 // testExecuteCommandStdin executes the given cobra command with the stdin
-// writer w and returns the stdout, stderr, and any errors that occur during
+// reader w and returns the stdout, stderr, and any errors that occur during
 // execution. It is safe for concurrent use if and only if the cobra command is
 // safe for concurrent use (e.g. does not read or set global state). The
 // convenience function [testExecuteCommand] exists for calling without stdin.

--- a/pkg/cli/token_test.go
+++ b/pkg/cli/token_test.go
@@ -181,7 +181,7 @@ func (j *fakeJVS) CreateJustification(_ context.Context, req *jvspb.CreateJustif
 
 	b, err := jwt.Sign(token, jwt.WithKey(jwa.HS256, []byte("testing")))
 	if err != nil {
-		return nil, fmt.Errorf("failed to sign breakglass token: %w", err)
+		return nil, fmt.Errorf("failed to sign token: %w", err)
 	}
 
 	return &jvspb.CreateJustificationResponse{

--- a/pkg/config/cli_config.go
+++ b/pkg/config/cli_config.go
@@ -30,13 +30,8 @@ type CLIConfig struct {
 	// Server is the JVS server address.
 	Server string `yaml:"server,omitempty"`
 
-	// Authentication is the authentication config.
-	Authentication *CLIAuthentication `yaml:"authentication,omitempty"`
-}
-
-// CLIAuthentication is the CLI authentication config.
-type CLIAuthentication struct {
-	// Insecure indiates whether to use insecured connection to the JVS server.
+	// Insecure indicates whether the CLI should allow an insecure connection to
+	// the server.
 	Insecure bool `yaml:"insecure,omitempty"`
 }
 
@@ -51,10 +46,6 @@ func (cfg *CLIConfig) Validate() error {
 			cfg.Version, CLIConfigVersions.List()))
 	}
 
-	if cfg.Server == "" {
-		err = multierror.Append(err, fmt.Errorf("missing JVS server address"))
-	}
-
 	return err.ErrorOrNil()
 }
 
@@ -62,8 +53,5 @@ func (cfg *CLIConfig) Validate() error {
 func (cfg *CLIConfig) SetDefault() {
 	if cfg.Version == "" {
 		cfg.Version = "1"
-	}
-	if cfg.Authentication == nil {
-		cfg.Authentication = &CLIAuthentication{}
 	}
 }

--- a/pkg/config/cli_config_test.go
+++ b/pkg/config/cli_config_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestCLIConfig_Validate(t *testing.T) {
@@ -31,19 +30,17 @@ func TestCLIConfig_Validate(t *testing.T) {
 	}{
 		{
 			name: "no_error",
-			cfg:  &CLIConfig{Server: "example.com"},
+			cfg: &CLIConfig{
+				Server:   "example.com",
+				Insecure: false,
+			},
 		},
 		{
 			name: "bad_version",
 			cfg: &CLIConfig{
 				Version: "255",
 			},
-			wantErr: "missing JVS server address",
-		},
-		{
-			name:    "missing_server_error",
-			cfg:     &CLIConfig{},
-			wantErr: "missing JVS server address",
+			wantErr: `version "255" is invalid`,
 		},
 	}
 
@@ -54,36 +51,6 @@ func TestCLIConfig_Validate(t *testing.T) {
 			err := tc.cfg.Validate()
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Errorf("unexpected err: %s", diff)
-			}
-		})
-	}
-}
-
-func TestCLIConfig_SetDefault(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		cfg     *CLIConfig
-		wantCfg *CLIConfig
-	}{{
-		name: "default_empty_authentication",
-		cfg:  &CLIConfig{},
-		wantCfg: &CLIConfig{
-			Version:        "1",
-			Authentication: &CLIAuthentication{},
-		},
-	}}
-
-	for _, tc := range tests {
-		tc := tc
-
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			tc.cfg.SetDefault()
-			if diff := cmp.Diff(tc.wantCfg, tc.cfg); diff != "" {
-				t.Errorf("config with defaults (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This removes the use of global variables for state in pkg/cli, which has the added benefit of allowing CLI tests to run in parallel. This new pattern ensures configuration is loaded and passed to child commands.

Fixes #133 