### PR TITLE
fix: Don't need to set primary key if we fail to create new key

### DIFF
--- a/pkg/jvscrypto/rotation_handler.go
+++ b/pkg/jvscrypto/rotation_handler.go
@@ -274,6 +274,7 @@ func (h *RotationHandler) performActions(ctx context.Context, keyName string, ac
 			newVer, err := h.performCreateNew(ctx, keyName)
 			if err != nil {
 				result = multierror.Append(result, err)
+				continue
 			}
 			logger.Info("Promoting immediately.")
 			if err := SetPrimary(ctx, h.KMSClient, keyName, newVer.Name); err != nil {

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -290,7 +290,7 @@ func TestPerformActions(t *testing.T) {
 			},
 		},
 		{
-			name: "create",
+			name: "create_new_and_promote",
 			actions: []*actionTuple{
 				{
 					ActionCreateNewAndPromote,
@@ -320,6 +320,28 @@ func TestPerformActions(t *testing.T) {
 				},
 			},
 			expectedPrimary: PrimaryLabelPrefix + versionSuffix + "-new",
+		},
+		{
+			name: "create_new_and_promote_with_failure",
+			actions: []*actionTuple{
+				{
+					ActionCreateNewAndPromote,
+					&kmspb.CryptoKeyVersion{
+						State: kmspb.CryptoKeyVersion_ENABLED,
+						Name:  versionName,
+					},
+				},
+			},
+			serverErr: fmt.Errorf("key creation failed"),
+			wantErr:   "1 error occurred:\n\t* key creation failed: rpc error: code = Unknown desc = key creation failed\n\n",
+			expectedRequests: []proto.Message{
+				&kmspb.CreateCryptoKeyVersionRequest{
+					Parent:           parent,
+					CryptoKeyVersion: &kmspb.CryptoKeyVersion{},
+				},
+			},
+			priorPrimary:    PrimaryLabelPrefix + versionSuffix,
+			expectedPrimary: PrimaryLabelPrefix + versionSuffix,
 		},
 		{
 			name: "destroy",


### PR DESCRIPTION
fix #103 
Don't need to set primary key if we fail to create new key