### PR TITLE
feat: add validate cmd

### DIFF
--- a/docs/cli-tool.md
+++ b/docs/cli-tool.md
@@ -36,7 +36,7 @@ following block in the config:
 insecure: true
 ```
 
-JWKS endpoint is also required if you want to validate justification tokens, it will default to the server domain if it is not specified.
+JWKS endpoint is also required if you want to validate justification tokens, it will default to the server domain + `/.well-known/jwks` if it is not specified.
 
 ```yaml
 jwks_endpoint: https://example.com/.well-known/jwks

--- a/docs/cli-tool.md
+++ b/docs/cli-tool.md
@@ -36,8 +36,13 @@ following block in the config:
 insecure: true
 ```
 
-Alternatively, both of these values could be provided via CLI flags `--server`
-and `--insecure`.
+JWKS endpoint is also required if you want to validate justification tokens via CLI, it will default to the server domain if it is not specified.
+
+```yaml
+jwks_endpoint: https://example.com/.well-known/jwks
+```
+
+Alternatively, all of these values could be provided via CLI flags `--server`, `--insecure`, and `--jwks_endpoint`.
 
 ## Command
 
@@ -66,3 +71,13 @@ jvsctl token --breakglass --explanation "jvs is down" --ttl 30m
 In certain cases, we might need to bypass JVS for minting signed JVS tokens.
 E.g. JVS couldn't verify a justification because the ticket system is down. In
 such cases, we can mint break-glass token instead.
+
+We are also able to validate JVS tokens, examples are provided as below.
+
+```shell
+jvsctl validate --token "example token"
+
+# or pass token via pipe
+echo "${JVS_TOKEN}" | jvsctl validate --token -
+cat /tmp/jvs_token | jvsctl validate --token -
+```

--- a/docs/cli-tool.md
+++ b/docs/cli-tool.md
@@ -36,7 +36,7 @@ following block in the config:
 insecure: true
 ```
 
-JWKS endpoint is also required if you want to validate justification tokens via CLI, it will default to the server domain if it is not specified.
+JWKS endpoint is also required if you want to validate justification tokens, it will default to the server domain if it is not specified.
 
 ```yaml
 jwks_endpoint: https://example.com/.well-known/jwks
@@ -78,6 +78,6 @@ We are also able to validate JVS tokens, examples are provided as below.
 jvsctl validate --token "example token"
 
 # or pass token via pipe
-echo "${JVS_TOKEN}" | jvsctl validate --token -
-cat /tmp/jvs_token | jvsctl validate --token -
+echo $JVS_TOKEN | jvsctl validate --token -
+cat /tmp/jvs_token.txt | jvsctl validate --token -
 ```

--- a/docs/jvs-quick-setup.md
+++ b/docs/jvs-quick-setup.md
@@ -91,7 +91,7 @@ will also get created.
     jvsctl validate --token "example token" --jwks_endpoint ${JWKS_ENDPOINT}
 
     # or pass token via pipe
-    echo "${JVS_TOKEN}" | jvsctl validate --token -
+    echo $JVS_TOKEN | jvsctl validate --token -
     cat /tmp/jvs_token.txt | jvsctl validate --token -
     ```
 

--- a/docs/jvs-quick-setup.md
+++ b/docs/jvs-quick-setup.md
@@ -72,11 +72,11 @@ will also get created.
 
 ### Justification API
 
-1.  Export the jvs server with the domain part of the `jvs_server_url` from
-    Terraform outputs like `jvs-e2e-xxxx-uc.a.run.app`
+1.  From Terraform outputs, export the jvs server with the domain part of the `jvs_server_url`  like `jvs-e2e-xxxx-uc.a.run.app`, and export the `public_key_server_url` if you want to validate token via CLI.
 
     ```shell
     export SERVER=<jvs_server_domain>:443
+    export JWKS_ENDPOINT=<public_key_server_url>/.well-known/jwks
     ```
 
 2.  Create Justification Token via [jvsctl](cli-tool.md):
@@ -85,8 +85,15 @@ will also get created.
     jvsctl token --explanation "issues/12345" --ttl 30m --server ${SERVER}
     ```
 
-**TODO(#112):** Once we have the "validate token" command, we can even validate
-it.
+3.  Validate Justification [jvsctl](cli-tool.md):
+
+    ```shell
+    jvsctl validate --token "example token" --jwks_endpoint ${JWKS_ENDPOINT}
+
+    # or pass token via pipe
+    echo "${JVS_TOKEN}" | jvsctl validate --token -
+    cat /tmp/jvs_token.txt | jvsctl validate --token -
+    ```
 
 ### Public Key API
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -52,9 +52,11 @@ func newRootCmd(cfg *config.CLIConfig) *cobra.Command {
 		"path to a file on disk for the jvs configuration")
 	cmd.PersistentFlags().StringVar(&cfg.Server, "server", "127.0.0.1:8080", "IP or DNS address to the JVS server")
 	cmd.PersistentFlags().BoolVar(&cfg.Insecure, "insecure", false, "allow an insecure connection to the JVS server")
+	cmd.PersistentFlags().StringVar(&cfg.JWKSEndpoint, "jwks_endpoint", "", "JWKS publick key endpoint")
 
 	// Subcommands
 	cmd.AddCommand(newTokenCmd(cfg))
+	cmd.AddCommand(newValidateCmd(cfg))
 
 	return cmd
 }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -45,18 +45,17 @@ jwks_endpoint: "https://1.2.3.4:8080/.well-known/jwks"
 	})
 
 	cases := []struct {
-		name            string
-		args            []string
-		expConfig       *config.CLIConfig
-		expJWKSEndpoint string
+		name      string
+		args      []string
+		expConfig *config.CLIConfig
 	}{
 		{
 			name: "default_config",
 			expConfig: &config.CLIConfig{
-				Version: "1",
-				Server:  "127.0.0.1:8080",
+				Version:      "1",
+				Server:       "127.0.0.1:8080",
+				JWKSEndpoint: "https://127.0.0.1:8080/.well-known/jwks",
 			},
-			expJWKSEndpoint: "https://127.0.0.1:8080/.well-known/jwks",
 		},
 		{
 			name: "flag_config",
@@ -67,26 +66,25 @@ jwks_endpoint: "https://1.2.3.4:8080/.well-known/jwks"
 				JWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 				Insecure:     true,
 			},
-			expJWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 		},
 		{
 			name: "flag_server",
 			args: []string{"--server", "1.2.3.4:5678"},
 			expConfig: &config.CLIConfig{
-				Version: "1",
-				Server:  "1.2.3.4:5678",
+				Version:      "1",
+				Server:       "1.2.3.4:5678",
+				JWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 			},
-			expJWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 		},
 		{
 			name: "flag_insecure",
 			args: []string{"--insecure"},
 			expConfig: &config.CLIConfig{
-				Version:  "1",
-				Server:   "127.0.0.1:8080",
-				Insecure: true,
+				Version:      "1",
+				Server:       "127.0.0.1:8080",
+				Insecure:     true,
+				JWKSEndpoint: "https://127.0.0.1:8080/.well-known/jwks",
 			},
-			expJWKSEndpoint: "https://127.0.0.1:8080/.well-known/jwks",
 		},
 		{
 			name: "flag_jwks_endpoint",
@@ -96,7 +94,6 @@ jwks_endpoint: "https://1.2.3.4:8080/.well-known/jwks"
 				Server:       "127.0.0.1:8080",
 				JWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 			},
-			expJWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 		},
 	}
 
@@ -123,9 +120,6 @@ jwks_endpoint: "https://1.2.3.4:8080/.well-known/jwks"
 
 			if diff := cmp.Diff(tc.expConfig, &cfg); diff != "" {
 				t.Errorf("config (-want, +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.expJWKSEndpoint, cfg.GetJWKSEndpoint()); diff != "" {
-				t.Errorf("jwksEndpoint (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -1,0 +1,191 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/jvs/client-lib/go/client"
+	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// validateCmdOptions holds all the inputs and flags for the validate subcommand.
+type validateCmdOptions struct {
+	config *config.CLIConfig
+
+	token string
+}
+
+// newValidateCmd creates a new subcommand for validating tokens.
+func newValidateCmd(cfg *config.CLIConfig) *cobra.Command {
+	opts := &validateCmdOptions{
+		config: cfg,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate the input token",
+		Long: strings.Trim(`
+Validate the given justification token passed via token flag or pipe.
+The output will be a tablized view of validation result, token justification
+and standard claims put together, or any errors that occured.
+
+For example:
+
+    # Validate the justification token string
+    jvsctl validate --token "example token string"
+
+    # Validate the justification token read from pipe
+    cat token.txt | jvsctl token --token -
+
+    # Output
+	-------RESULT-------
+	validated!
+	breakglass  false
+	----JUSTIFICATION----
+	explanation  "test"
+	---STANDARD CLAIMS---
+	aud  ["dev.abcxyz.jvs"]
+	iat  "2022-01-01T00:00:00Z"
+	iss  "jvsctl"
+	jti  "test-jwt"
+	nbf  "2022-01-01T00:00:00Z"
+	sub  "jvsctl"
+`, "\n"),
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runValidateCmd(cmd, opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.token, "token", "t", "",
+		"The JVS token that needs validation")
+	cmd.MarkFlagRequired("token") //nolint // not expect err
+
+	return cmd
+}
+
+func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string) error {
+	ctx := context.Background()
+
+	jvsclient, err := client.NewJVSClient(ctx, &client.JVSConfig{
+		Version:         "1",
+		JWKSEndpoint:    opts.config.GetJWKSEndpoint(),
+		CacheTimeout:    5 * time.Minute,
+		AllowBreakglass: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create jvs client: %w", err)
+	}
+
+	if opts.token == "-" {
+		stdin, ok := cmd.InOrStdin().(*os.File)
+		// Default to os.Stdin when input is not of type os.File
+		if !ok {
+			stdin = os.Stdin
+		}
+		stat, _ := stdin.Stat()
+		// Check whether the input is from pipe
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			// Read from pipe
+			buf, err := io.ReadAll(io.LimitReader(stdin, 64*1_000))
+			if err != nil {
+				return fmt.Errorf("failed to read from pipe: %w", err)
+			}
+			opts.token = string(buf)
+		} else {
+			// Use user input
+			fmt.Print("Enter token: ")
+			fmt.Scanf("%s", &opts.token)
+		}
+	}
+
+	// Validate token
+	breakglass := false
+	token, err := jvspb.ParseBreakglassToken(opts.token)
+	if err != nil {
+		return fmt.Errorf("failed to parse breakglass token: %w", err)
+	}
+	if token != nil {
+		breakglass = true
+	} else {
+		token, err = jvsclient.ValidateJWT(opts.token)
+		if err != nil {
+			return fmt.Errorf("failed to validate jwt: %w", err)
+		}
+	}
+
+	// Write validation result
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintf(w, "-------RESULT-------\nvalidated!\nbreakglass\t%t\n", breakglass); err != nil {
+		return err
+	}
+
+	// Write justifications as a table
+	if _, err := fmt.Fprintln(w, "----JUSTIFICATION----"); err != nil {
+		return err
+	}
+	justs, err := jvspb.GetJustifications(token)
+	if err != nil {
+		return fmt.Errorf("failed to get justifications from token")
+	}
+	for _, j := range justs {
+		if _, err := fmt.Fprintf(w, "%s\t\"%s\"\n", j.GetCategory(), j.GetValue()); err != nil {
+			return err
+		}
+	}
+
+	// Convert standard claims into a map, excluding justifications claim which is already handled
+	claimsMap, err := token.AsMap(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to convert token into map: %w", err)
+	}
+	delete(claimsMap, "justs")
+	claims := make(map[string]string, len(claimsMap))
+	claimsKeys := make([]string, 0, len(claimsMap))
+	for k, v := range claimsMap {
+		claimsKeys = append(claimsKeys, k)
+		jv, err := json.Marshal(v)
+		if err != nil {
+			claims[k] = fmt.Sprintf("failed to marshal to json: %s", err)
+		} else {
+			claims[k] = string(jv)
+		}
+	}
+
+	// Write standard claims in increasing order as a table
+	sort.Strings(claimsKeys)
+	if _, err := fmt.Fprintln(w, "---STANDARD CLAIMS---"); err != nil {
+		return err
+	}
+	for _, k := range claimsKeys {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", k, claims[k]); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return nil
+}

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -28,6 +27,7 @@ import (
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/abcxyz/jvs/client-lib/go/client"
 	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +35,7 @@ import (
 type validateCmdOptions struct {
 	config *config.CLIConfig
 
+	// token flag to the command.
 	token string
 }
 
@@ -48,9 +49,8 @@ func newValidateCmd(cfg *config.CLIConfig) *cobra.Command {
 		Use:   "validate",
 		Short: "Validate the input token",
 		Long: strings.Trim(`
-Validate the given justification token passed via token flag or pipe.
-The output will be a tablized view of validation result, token justification
-and standard claims put together, or any errors that occured.
+Validate the given justification token and output the justifications and other
+standard claims if it's valid. If the token is invalid, an error will be returned.
 
 For example:
 
@@ -58,21 +58,22 @@ For example:
     jvsctl validate --token "example token string"
 
     # Validate the justification token read from pipe
-    cat token.txt | jvsctl token --token -
+    cat token.txt | jvsctl validate --token -
 
     # Output
-	-------RESULT-------
-	validated!
-	breakglass  false
-	----JUSTIFICATION----
-	explanation  "test"
-	---STANDARD CLAIMS---
-	aud  ["dev.abcxyz.jvs"]
-	iat  "2022-01-01T00:00:00Z"
-	iss  "jvsctl"
-	jti  "test-jwt"
-	nbf  "2022-01-01T00:00:00Z"
-	sub  "jvsctl"
+    ------BREAKGLASS------
+    false
+
+    ----JUSTIFICATIONs----
+    explanation  "test"
+
+    ---STANDARD CLAIMS---
+    aud  ["dev.abcxyz.jvs"]
+    iat  "2022-01-01T00:00:00Z"
+    iss  "jvsctl"
+    jti  "test-jwt"
+    nbf  "2022-01-01T00:00:00Z"
+    sub  "jvsctl"
 `, "\n"),
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -81,10 +82,11 @@ For example:
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.token, "token", "t", "",
-		"The JVS token that needs validation")
+	flags.StringVarP(&opts.token, "token", "t", "", `
+The JVS token that needs validation, can be passed as string or via pipe
+`)
 	cmd.MarkFlagRequired("token") //nolint // not expect err
-
+	// TODO: #140 add output format flag.
 	return cmd
 }
 
@@ -93,7 +95,7 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 
 	jvsclient, err := client.NewJVSClient(ctx, &client.JVSConfig{
 		Version:         "1",
-		JWKSEndpoint:    opts.config.GetJWKSEndpoint(),
+		JWKSEndpoint:    opts.config.JWKSEndpoint,
 		CacheTimeout:    5 * time.Minute,
 		AllowBreakglass: true,
 	})
@@ -102,24 +104,12 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 	}
 
 	if opts.token == "-" {
-		stdin, ok := cmd.InOrStdin().(*os.File)
-		// Default to os.Stdin when input is not of type os.File
-		if !ok {
-			stdin = os.Stdin
-		}
-		stat, _ := stdin.Stat()
-		// Check whether the input is from pipe
-		if (stat.Mode() & os.ModeCharDevice) == 0 {
-			// Read from pipe
-			buf, err := io.ReadAll(io.LimitReader(stdin, 64*1_000))
-			if err != nil {
-				return fmt.Errorf("failed to read from pipe: %w", err)
-			}
-			opts.token = string(buf)
-		} else {
-			// Use user input
+		buf, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), 64*1_000))
+		if err != nil || len(buf) == 0 {
 			fmt.Print("Enter token: ")
 			fmt.Scanf("%s", &opts.token)
+		} else {
+			opts.token = string(buf)
 		}
 	}
 
@@ -138,14 +128,25 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 		}
 	}
 
-	// Write validation result
+	// Output the token into three subtables: breakglass, justification,
+	// and standard claims.
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintf(w, "-------RESULT-------\nvalidated!\nbreakglass\t%t\n", breakglass); err != nil {
+	if _, err := fmt.Fprintf(w, "-----BREAKGLASS-----\n%t\n", breakglass); err != nil {
 		return err
 	}
 
-	// Write justifications as a table
-	if _, err := fmt.Fprintln(w, "----JUSTIFICATION----"); err != nil {
+	if err := writeJustification(w, token); err != nil {
+		return err
+	}
+	if err := writeStandardClaims(ctx, w, token); err != nil {
+		return err
+	}
+	w.Flush()
+	return nil
+}
+
+func writeJustification(w *tabwriter.Writer, token jwt.Token) error {
+	if _, err := fmt.Fprintln(w, "\n----JUSTIFICATION----"); err != nil {
 		return err
 	}
 	justs, err := jvspb.GetJustifications(token)
@@ -157,7 +158,10 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 			return err
 		}
 	}
+	return nil
+}
 
+func writeStandardClaims(ctx context.Context, w *tabwriter.Writer, token jwt.Token) error {
 	// Convert standard claims into a map, excluding justifications claim which is already handled
 	claimsMap, err := token.AsMap(ctx)
 	if err != nil {
@@ -178,7 +182,7 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 
 	// Write standard claims in increasing order as a table
 	sort.Strings(claimsKeys)
-	if _, err := fmt.Fprintln(w, "---STANDARD CLAIMS---"); err != nil {
+	if _, err := fmt.Fprintln(w, "\n---STANDARD CLAIMS---"); err != nil {
 		return err
 	}
 	for _, k := range claimsKeys {
@@ -186,6 +190,5 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 			return err
 		}
 	}
-	w.Flush()
 	return nil
 }

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -31,6 +31,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// cacheTimeout is required for creating jvs client via jvs config, it is not really used since cache is expired when CLI exits.
+const cacheTimeout = 5 * time.Minute
+
 // validateCmdOptions holds all the inputs and flags for the validate subcommand.
 type validateCmdOptions struct {
 	config *config.CLIConfig
@@ -96,7 +99,7 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 	jvsclient, err := client.NewJVSClient(ctx, &client.JVSConfig{
 		Version:         "1",
 		JWKSEndpoint:    opts.config.JWKSEndpoint,
-		CacheTimeout:    5 * time.Minute,
+		CacheTimeout:    cacheTimeout,
 		AllowBreakglass: true,
 	})
 	if err != nil {

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -126,12 +126,13 @@ func TestNewValidateCmd(t *testing.T) {
 				JWKSEndpoint: svr.URL + path,
 			},
 			args: []string{"-t", signedToken},
-			expOut: `-------RESULT-------
-validated!
-breakglass  false
+			expOut: `-----BREAKGLASS-----
+false
+
 ----JUSTIFICATION----
 explanation  "test"
 foo          "bar"
+
 ---STANDARD CLAIMS---
 aud  ["dev.abcxyz.jvs"]
 iat  "1970-01-01T00:00:00Z"
@@ -147,11 +148,12 @@ sub  "jvsctl"
 				JWKSEndpoint: svr.URL + path,
 			},
 			args: []string{"-t", breakglassToken},
-			expOut: `-------RESULT-------
-validated!
-breakglass  true
+			expOut: `-----BREAKGLASS-----
+true
+
 ----JUSTIFICATION----
 breakglass  "prod is down"
+
 ---STANDARD CLAIMS---
 aud  ["dev.abcxyz.jvs"]
 iat  "1970-01-01T00:00:00Z"
@@ -168,12 +170,13 @@ sub  "jvsctl"
 			},
 			args: []string{"-t", "-"},
 			pipe: true,
-			expOut: `-------RESULT-------
-validated!
-breakglass  false
+			expOut: `-----BREAKGLASS-----
+false
+
 ----JUSTIFICATION----
 explanation  "test"
 foo          "bar"
+
 ---STANDARD CLAIMS---
 aud  ["dev.abcxyz.jvs"]
 iat  "1970-01-01T00:00:00Z"

--- a/pkg/cli/validate_test.go
+++ b/pkg/cli/validate_test.go
@@ -1,0 +1,265 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/abcxyz/jvs/pkg/justification"
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+func TestNewValidateCmd(t *testing.T) {
+	t.Parallel()
+
+	// Setup jwks server
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyID := "test_key_id"
+	ecdsaKey, err := jwk.FromRaw(privateKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ecdsaKey.Set(jwk.KeyIDKey, keyID); err != nil {
+		t.Fatal(err)
+	}
+	jwks := make(map[string][]jwk.Key)
+	jwks["keys"] = []jwk.Key{ecdsaKey}
+
+	j, err := json.MarshalIndent(jwks, "", " ")
+	if err != nil {
+		t.Fatal("couldn't create jwks json")
+	}
+	path := "/.well-known/jwks"
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "%s", j)
+	})
+
+	svr := httptest.NewServer(mux)
+
+	t.Cleanup(func() {
+		svr.Close()
+	})
+
+	// Build test tokens
+	token := testTokenBuilder(t)
+	if err := jvspb.SetJustifications(token, []*jvspb.Justification{
+		{
+			Category: "explanation",
+			Value:    "test",
+		},
+		{
+			Category: "foo",
+			Value:    "bar",
+		},
+	}); err != nil {
+		t.Fatalf("failed to set justifications in token: %s", err)
+	}
+	signedToken := testSignToken(t, token, privateKey, keyID)
+	breakglassToken, err := jvspb.CreateBreakglassToken(token, "prod is down")
+	if err != nil {
+		t.Fatalf("failed to build breakglass token: %s", err)
+	}
+
+	cases := []struct {
+		name   string
+		config *config.CLIConfig
+		args   []string
+		pipe   bool
+		expOut string
+		expErr string
+	}{
+		{
+			name:   "too_many_args",
+			args:   []string{"foo"},
+			expErr: `accepts 0 arg(s)`,
+		},
+		{
+			name:   "missing_token",
+			args:   nil,
+			expErr: `"token" not set`,
+		},
+		{
+			name: "invalid_token",
+			config: &config.CLIConfig{
+				JWKSEndpoint: svr.URL + path,
+			},
+			args:   []string{"-t=invalid token"},
+			expErr: `failed to parse token headers`,
+		},
+		{
+			name: "signed",
+			config: &config.CLIConfig{
+				JWKSEndpoint: svr.URL + path,
+			},
+			args: []string{"-t", signedToken},
+			expOut: `-------RESULT-------
+validated!
+breakglass  false
+----JUSTIFICATION----
+explanation  "test"
+foo          "bar"
+---STANDARD CLAIMS---
+aud  ["dev.abcxyz.jvs"]
+iat  "1970-01-01T00:00:00Z"
+iss  "jvsctl"
+jti  "test-jwt"
+nbf  "1970-01-01T00:00:00Z"
+sub  "jvsctl"
+`,
+		},
+		{
+			name: "breakglass",
+			config: &config.CLIConfig{
+				JWKSEndpoint: svr.URL + path,
+			},
+			args: []string{"-t", breakglassToken},
+			expOut: `-------RESULT-------
+validated!
+breakglass  true
+----JUSTIFICATION----
+breakglass  "prod is down"
+---STANDARD CLAIMS---
+aud  ["dev.abcxyz.jvs"]
+iat  "1970-01-01T00:00:00Z"
+iss  "jvsctl"
+jti  "test-jwt"
+nbf  "1970-01-01T00:00:00Z"
+sub  "jvsctl"
+`,
+		},
+		{
+			name: "signed_from_pipe",
+			config: &config.CLIConfig{
+				JWKSEndpoint: svr.URL + path,
+			},
+			args: []string{"-t", "-"},
+			pipe: true,
+			expOut: `-------RESULT-------
+validated!
+breakglass  false
+----JUSTIFICATION----
+explanation  "test"
+foo          "bar"
+---STANDARD CLAIMS---
+aud  ["dev.abcxyz.jvs"]
+iat  "1970-01-01T00:00:00Z"
+iss  "jvsctl"
+jti  "test-jwt"
+nbf  "1970-01-01T00:00:00Z"
+sub  "jvsctl"
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newValidateCmd(tc.config)
+			var stdout string
+			var gotErr error
+			if tc.pipe {
+				// create tempFile with token
+				tempFile, err := os.CreateTemp("", "validate_test*")
+				if err != nil {
+					t.Errorf("failed to create temp file: %s", err)
+				}
+				// remove tempFile
+				defer os.Remove(tempFile.Name())
+
+				if _, err := tempFile.Write([]byte(signedToken)); err != nil {
+					t.Errorf("failed to write to temp file: %s", err)
+				}
+				if _, err := tempFile.Seek(0, 0); err != nil {
+					t.Errorf("failed to seek to the beginning of the temp file: %s", err)
+				}
+
+				stdout, _, gotErr = testExecuteCommandStdin(t, cmd, tempFile, tc.args...)
+				if err := tempFile.Close(); err != nil {
+					t.Errorf("failed to close temp file: %s", err)
+				}
+			} else {
+				stdout, _, gotErr = testExecuteCommand(t, cmd, tc.args...)
+			}
+			if diff := testutil.DiffErrString(gotErr, tc.expErr); diff != "" {
+				t.Fatal(diff)
+			}
+			if gotErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expOut, stdout); diff != "" {
+				t.Errorf("output: diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func testTokenBuilder(tb testing.TB) jwt.Token {
+	tb.Helper()
+
+	now := time.Unix(0, 0).UTC()
+	token, err := jwt.NewBuilder().
+		Audience([]string{justification.DefaultAudience}).
+		IssuedAt(now).
+		Issuer(Issuer).
+		JwtID("test-jwt").
+		NotBefore(now).
+		Subject(Subject).
+		Build()
+	if err != nil {
+		tb.Fatalf("failed to create unsigned token: %s", err)
+	}
+	return token
+}
+
+func testSignToken(tb testing.TB, unsignedToken jwt.Token, privateKey *ecdsa.PrivateKey, keyID string) string {
+	tb.Helper()
+
+	headers := jws.NewHeaders()
+	if err := headers.Set(jws.KeyIDKey, keyID); err != nil {
+		tb.Fatal(err)
+	}
+
+	token, err := jwt.Sign(unsignedToken, jwt.WithKey(jwa.ES256, privateKey, jws.WithProtectedHeaders(headers)))
+	if err != nil {
+		tb.Fatalf("failed to sign token: %s", err)
+	}
+	return string(token)
+}

--- a/pkg/config/cli_config.go
+++ b/pkg/config/cli_config.go
@@ -59,12 +59,9 @@ func (cfg *CLIConfig) SetDefault() {
 	if cfg.Version == "" {
 		cfg.Version = "1"
 	}
-}
 
-// Default to server's doman if JWKSEndpoint is not specified.
-func (cfg *CLIConfig) GetJWKSEndpoint() string {
+	// Default to server's doman if JWKSEndpoint is not specified.
 	if cfg.JWKSEndpoint == "" && cfg.Server != "" {
-		return fmt.Sprintf("https://%s:8080/.well-known/jwks", strings.Split(cfg.Server, ":")[0])
+		cfg.JWKSEndpoint = fmt.Sprintf("https://%s:8080/.well-known/jwks", strings.Split(cfg.Server, ":")[0])
 	}
-	return cfg.JWKSEndpoint
 }

--- a/pkg/config/cli_config.go
+++ b/pkg/config/cli_config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -33,6 +34,10 @@ type CLIConfig struct {
 	// Insecure indicates whether the CLI should allow an insecure connection to
 	// the server.
 	Insecure bool `yaml:"insecure,omitempty"`
+
+	// JWKSEndpoint is the full path (including protocol and port) to the JWKS
+	// endpoint on a JVS server (e.g. https://example.com/.well-known/jwks).
+	JWKSEndpoint string `yaml:"jwks_endpoint,omitempty" mapstructure:"jwks_endpoint"`
 }
 
 // Validate checks if the config is valid.
@@ -54,4 +59,12 @@ func (cfg *CLIConfig) SetDefault() {
 	if cfg.Version == "" {
 		cfg.Version = "1"
 	}
+}
+
+// Default to server's doman if JWKSEndpoint is not specified.
+func (cfg *CLIConfig) GetJWKSEndpoint() string {
+	if cfg.JWKSEndpoint == "" && cfg.Server != "" {
+		return fmt.Sprintf("https://%s:8080/.well-known/jwks", strings.Split(cfg.Server, ":")[0])
+	}
+	return cfg.JWKSEndpoint
 }

--- a/pkg/config/cli_config_test.go
+++ b/pkg/config/cli_config_test.go
@@ -58,37 +58,51 @@ func TestCLIConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestCLIConfig_GetJWKSEndpoint(t *testing.T) {
+func TestCLIConfig_SetDefault(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		cfg              *CLIConfig
-		wantJWKSEndpoint string
+		name    string
+		cfg     *CLIConfig
+		wantCfg *CLIConfig
 	}{
 		{
-			name: "jwks_endpoint_not_empty",
+			name: "not_default",
 			cfg: &CLIConfig{
-				Server:       "127.0.0.1:8080",
+				Version:      "2",
+				Server:       "1.2.3.4:5678",
 				Insecure:     false,
 				JWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 			},
-			wantJWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
-		},
-		{
-			name: "default",
-			cfg: &CLIConfig{
-				Server:   "127.0.0.1:8080",
-				Insecure: false,
+			wantCfg: &CLIConfig{
+				Version:      "2",
+				Server:       "1.2.3.4:5678",
+				Insecure:     false,
+				JWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
 			},
-			wantJWKSEndpoint: "https://127.0.0.1:8080/.well-known/jwks",
 		},
 		{
-			name: "empty",
+			name: "default_server",
 			cfg: &CLIConfig{
 				Insecure: false,
 			},
-			wantJWKSEndpoint: "",
+			wantCfg: &CLIConfig{
+				Version:  "1",
+				Insecure: false,
+			},
+		},
+		{
+			name: "default_jwks_endpoint",
+			cfg: &CLIConfig{
+				Server:   "1.2.3.4:5678",
+				Insecure: false,
+			},
+			wantCfg: &CLIConfig{
+				Version:      "1",
+				Server:       "1.2.3.4:5678",
+				Insecure:     false,
+				JWKSEndpoint: "https://1.2.3.4:8080/.well-known/jwks",
+			},
 		},
 	}
 
@@ -96,8 +110,8 @@ func TestCLIConfig_GetJWKSEndpoint(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			gotJWKSEndpoint := tc.cfg.GetJWKSEndpoint()
-			if diff := cmp.Diff(tc.wantJWKSEndpoint, gotJWKSEndpoint); diff != "" {
+			tc.cfg.SetDefault()
+			if diff := cmp.Diff(tc.wantCfg, tc.cfg); diff != "" {
 				t.Errorf("Output: diff (-want, +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
address #112
1. make JWKSEndpoint default to server domain if not explicitly specified. 
2. validate cmd output will be in a table with three sections: result, justs, other claims. json and yaml are not considered here since JWT supports both already. 