### PR TITLE
chore: prepare pom.xml for maven package release

### DIFF
--- a/client-lib/java/pom.xml
+++ b/client-lib/java/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.abcxyz.jvs</groupId>
   <artifactId>jvs-client</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <dependencyManagement>
     <dependencies>
@@ -116,5 +116,37 @@
         <version>3.0.0-M7</version>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.1.0</version>
+      </extension>
+    </extensions>
   </build>
+
+  <!-- For releasing package to Artifact Registry -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
+    </snapshotRepository>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </modules>
 
   <properties>
-    <revision>1.0.0-SNAPSHOT</revision>
+    <revision>0.0.1-SNAPSHOT</revision>
   </properties>
 
   <!-- For releasing package to Artifact Registry -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,49 @@
   <groupId>com.abcxyz.jvs</groupId>
   <artifactId>jvs</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <modules>
     <module>client-lib/java</module>
   </modules>
+
+  <properties>
+    <revision>1.0.0-SNAPSHOT</revision>
+  </properties>
+
+  <!-- For releasing package to Artifact Registry -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
+    </snapshotRepository>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.1.0</version>
+      </extension>
+    </extensions>
+  </build>
+
 </project>


### PR DESCRIPTION
Part of https://github.com/abcxyz/jvs/issues/129

In the release workflow, we'd a step to run the following command to publish the package.

```
# [VERSION] like 0.0.1
mvn clean deploy -Drevision=[VERSION]
```

Ref: https://maven.apache.org/maven-ci-friendly.html

Maven packages are immutable and can't be overwritten. If needed, we would need to delete the existing version before publishing new ones. To delete, we can run:

```
gcloud artifacts versions delete [VERSION] --package=com.abcxyz.jvs:jvs --project=abcxyz-artifacts --repository=maven-repo --location=us --quiet
```