### PR TITLE
fix: issues in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       # Even though Artifact Registry allows versions starts with "v",
       # Maven's convention is to have versions without "v".
       run: |-
-        mvn clean deploy -Drevision=${${{ github.ref_name }}#v}
+        mvn clean deploy -Drevision=$(echo '${{ github.ref_name }}' | cut -c 2-)
 
 
   github-release:

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ go.work
 
 # Ignore goreleaser output
 dist/
+
+# Ignore google auth action cred file.
+gha-creds-*.json


### PR DESCRIPTION
1. Maven release is not removing prefix "v" properly
2. Google auth will generate a temporary cred file that makes the repo "dirty" and thus prevent goreleaser release