### PR TITLE
fix: multiple nit bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ COPY --from=distroless /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 COPY $APP /server
 
-USER nobody
+# Normally we would set this to run as "nobody".
+# But goreleaser builds the binary locally and sometimes it will mess up the permission
+# and cause "exec user process caused: permission denied".
+#
+# USER nobody
 
 # Run the web service on container startup.
 ENV PORT 8080

--- a/cmd/cert-rotation/main.go
+++ b/cmd/cert-rotation/main.go
@@ -91,7 +91,7 @@ func realMain(ctx context.Context) error {
 	defer kmsClient.Close()
 
 	var cfg config.CryptoConfig
-	if err := cfgloader.Load(ctx, cfg); err != nil {
+	if err := cfgloader.Load(ctx, &cfg); err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 

--- a/pkg/jvscrypto/kmsutil.go
+++ b/pkg/jvscrypto/kmsutil.go
@@ -133,7 +133,7 @@ func CryptoKeyVersionsFor(ctx context.Context, client *kms.KeyManagementClient, 
 	keyVersions := make(map[string]struct{}, len(versionsResults))
 	for _, result := range versionsResults {
 		if result.Error != nil {
-			return nil, err
+			return nil, result.Error
 		}
 
 		for _, v := range result.Value {
@@ -191,7 +191,7 @@ func PublicKeysFor(ctx context.Context, client *kms.KeyManagementClient, keyVers
 	final := make(map[string]crypto.PublicKey, len(publicKeysResults))
 	for _, result := range publicKeysResults {
 		if result.Error != nil {
-			return nil, fmt.Errorf("failed to fetch public key: %w", err)
+			return nil, fmt.Errorf("failed to fetch public key: %w", result.Error)
 		}
 		final[result.Value.name] = result.Value.publicKey
 	}


### PR DESCRIPTION
Bugs:

- Container images built on dev machine will have "exec user process caused: permission denied" issue on startup
- A config loading bug in cert rotation main.go
- Error propagation in kmsutil.go