### PR TITLE
Ensure logger exists on grpc context

### DIFF
--- a/cmd/cert-rotation/main.go
+++ b/cmd/cert-rotation/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/jvscrypto"
 	"github.com/abcxyz/pkg/cfgloader"
+	"github.com/abcxyz/pkg/gcputil"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/hashicorp/go-multierror"
 )
@@ -83,6 +84,8 @@ func realMain(ctx context.Context) error {
 		"commit", version.Commit,
 		"version", version.Version)
 
+	projectID := gcputil.ProjectID(ctx)
+
 	kmsClient, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to setup kms client: %w", err)
@@ -94,15 +97,17 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	handler := &jvscrypto.RotationHandler{
-		KMSClient:    kmsClient,
-		CryptoConfig: &cfg,
-	}
+	logger.Debugw("loaded configuration", "config", cfg)
 
 	mux := http.NewServeMux()
-	mux.Handle("/", &server{
-		handler: handler,
-	})
+	mux.Handle("/", logging.HTTPInterceptor(logger, projectID)(
+		&server{
+			handler: &jvscrypto.RotationHandler{
+				KMSClient:    kmsClient,
+				CryptoConfig: &cfg,
+			},
+		},
+	))
 
 	// Determine port for HTTP service.
 	port := os.Getenv("PORT")

--- a/cmd/manual-cert-actions/main.go
+++ b/cmd/manual-cert-actions/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/jvscrypto"
 	"github.com/abcxyz/pkg/cfgloader"
+	"github.com/abcxyz/pkg/gcputil"
 	"github.com/abcxyz/pkg/logging"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/sync/errgroup"
@@ -56,7 +57,10 @@ func realMain(ctx context.Context) error {
 		"commit", version.Commit,
 		"version", version.Version)
 
+	projectID := gcputil.ProjectID(ctx)
+
 	s := grpc.NewServer(grpc.ChainUnaryInterceptor(
+		logging.GRPCUnaryInterceptor(logger, projectID),
 		otelgrpc.UnaryServerInterceptor(),
 	))
 
@@ -64,6 +68,8 @@ func realMain(ctx context.Context) error {
 	if err := cfgloader.Load(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
+
+	logger.Debugw("loaded configuration", "config", cfg)
 
 	kmsClient, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/kms v1.8.0
-	github.com/abcxyz/pkg v0.1.2-0.20230106203017-d05e75ed64fa
+	github.com/abcxyz/pkg v0.1.2-0.20230125001932-da582a95bb8b
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
@@ -20,7 +20,7 @@ require (
 	golang.org/x/oauth2 v0.4.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/api v0.106.0
-	google.golang.org/grpc v1.52.0
+	google.golang.org/grpc v1.52.1
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -66,7 +66,7 @@ require (
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/abcxyz/pkg v0.1.2-0.20230106203017-d05e75ed64fa h1:RfAkfbvZ+LOIwTgfyDV4vi3wiVCNDqvtI2FroCQ6QDI=
-github.com/abcxyz/pkg v0.1.2-0.20230106203017-d05e75ed64fa/go.mod h1:vzO7x3uKaRbxbCCrQZvgxrglkVhMbf/1FlDgU/DJoxA=
+github.com/abcxyz/pkg v0.1.2-0.20230125001932-da582a95bb8b h1:9ubnTfMdttZNTIhWJm8eSyd9AInOAIgKWNAvIDYrMws=
+github.com/abcxyz/pkg v0.1.2-0.20230125001932-da582a95bb8b/go.mod h1:ZM2C+K92ftjvITPMNWru4F4YsMaobZ40ERo2iVR5Hag=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -541,8 +541,8 @@ google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2 h1:O97sLx/Xmb/KIZHB/2/BzofxBs5QmmR0LcihPtllmbc=
+google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -559,8 +559,8 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.52.0 h1:kd48UiU7EHsV4rnLyOJRuP/Il/UHE7gdDAQ+SZI7nZk=
-google.golang.org/grpc v1.52.0/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
+google.golang.org/grpc v1.52.1 h1:2NpOPk5g5Xtb0qebIEs7hNIa++PdtZLo2AQUpc1YnSU=
+google.golang.org/grpc v1.52.1/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
This ensures that the logger that is configured during setup is propagated to the actual GRPC service. Without this, we get a "default" logger which doesn't have the right format or log level.

This also updates to the latest abcxyz/pkg version and updates services to print out their configuration at debug level on boot.