### PR TITLE
Add configuration for setting default and max TTLs

### DIFF
--- a/pkg/jvscrypto/rotation_handler.go
+++ b/pkg/jvscrypto/rotation_handler.go
@@ -65,15 +65,15 @@ func (h *RotationHandler) RotateKey(ctx context.Context, key string) error {
 	// Get any relevant Key Version information from the StateStore
 	primaryName, err := GetPrimary(ctx, h.KMSClient, key)
 	if err != nil {
-		return fmt.Errorf("unable to determine primary: %w", err)
+		return fmt.Errorf("failed to determine primary: %w", err)
 	}
 	actions, err := h.determineActions(ctx, vers, primaryName, curTime)
 	if err != nil {
-		return fmt.Errorf("unable to determine cert actions: %w", err)
+		return fmt.Errorf("failed to determine cert actions: %w", err)
 	}
 
 	if err = h.performActions(ctx, key, actions); err != nil {
-		return fmt.Errorf("unable to perform some cert actions: %w", err)
+		return fmt.Errorf("failed to perform some cert actions: %w", err)
 	}
 	return nil
 }

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -88,6 +88,8 @@ func TestJVS(t *testing.T) {
 		KeyName:            keyName,
 		Issuer:             "ci-test",
 		SignerCacheTimeout: 1 * time.Nanosecond, // no caching
+		DefaultTTL:         15 * time.Minute,
+		MaxTTL:             2 * time.Hour,
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatal(err)
@@ -185,18 +187,6 @@ func TestJVS(t *testing.T) {
 				},
 				Ttl: &durationpb.Duration{
 					Seconds: 3600,
-				},
-			},
-			wantErr: "failed to validate request",
-		},
-		{
-			name: "no_ttl",
-			request: &jvspb.CreateJustificationRequest{
-				Justifications: []*jvspb.Justification{
-					{
-						Category: "explanation",
-						Value:    "This is a test.",
-					},
 				},
 			},
 			wantErr: "failed to validate request",


### PR DESCRIPTION
This introduces new configuration into the JVS server - DefaultTTL and MaxTTL. The DefaultTTL is the TTL that the server will assign if the client does not request a TTL. The MaxTTL is the maximum value a client can request. If a client requests a larger TTL than the MaxTTL, they will get an error back in the response. This required threading through some data into the response that was not previously provided.

Fixes GH-169
Closes GH-172