### PR TITLE
Accept a context in ValidateJWT

### DIFF
--- a/client-lib/go/client/jvs_client.go
+++ b/client-lib/go/client/jvs_client.go
@@ -58,7 +58,7 @@ func NewJVSClient(ctx context.Context, config *JVSConfig) (*JVSClient, error) {
 
 // ValidateJWT takes a jwt string, converts it to a JWT, and validates the
 // signature against the keys in the JWKs endpoint.
-func (j *JVSClient) ValidateJWT(jwtStr string) (jwt.Token, error) {
+func (j *JVSClient) ValidateJWT(ctx context.Context, jwtStr string) (jwt.Token, error) {
 	// Handle breakglass tokens
 	token, err := jvspb.ParseBreakglassToken(jwtStr)
 	if err != nil {
@@ -73,7 +73,7 @@ func (j *JVSClient) ValidateJWT(jwtStr string) (jwt.Token, error) {
 
 	// If we got this far, the token was not breakglass, so parse as normal.
 	token, err = jwt.ParseString(jwtStr,
-		jwt.WithContext(context.TODO()),
+		jwt.WithContext(ctx),
 		jvspb.WithTypedJustifications(),
 		jwt.WithKeySet(j.keys, jws.WithInferAlgorithmFromKey(true)),
 	)

--- a/client-lib/go/client/jvs_client_test.go
+++ b/client-lib/go/client/jvs_client_test.go
@@ -147,7 +147,7 @@ func TestValidateJWT(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create JVS client: %v", err)
 			}
-			res, err := client.ValidateJWT(tc.jwt)
+			res, err := client.ValidateJWT(ctx, tc.jwt)
 
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Errorf("Unexpected err: %s", diff)

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -139,7 +139,7 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 	if token != nil {
 		breakglass = true
 	} else {
-		token, err = jvsclient.ValidateJWT(opts.token)
+		token, err = jvsclient.ValidateJWT(ctx, opts.token)
 		if err != nil {
 			return fmt.Errorf("failed to validate jwt: %w", err)
 		}


### PR DESCRIPTION
This is technically a breaking API change, but given the limited number of clients, it feels okay to do this now.