### PR TITLE
Decouple authentication from jvsctl

### DIFF
--- a/pkg/cli/token_test.go
+++ b/pkg/cli/token_test.go
@@ -70,7 +70,6 @@ func TestNewTokenCmd(t *testing.T) {
 			},
 			args: []string{
 				"--explanation=for testing purposes",
-				"--disable-authn",
 			},
 			expErr: "testing server error",
 		},
@@ -82,7 +81,6 @@ func TestNewTokenCmd(t *testing.T) {
 			},
 			args: []string{
 				"--explanation=for testing purposes",
-				"--disable-authn",
 			},
 			expAudiences: []string{justification.DefaultAudience},
 			expJustifications: []*jvspb.Justification{


### PR DESCRIPTION
This marks authentication as optional and removes the automatic lookup of the local ID token. Users can still pass authentication using `-auth-token=$(gcloud auth print-identity-token)`, but this removes much of the auth lookup magic.