### PR TITLE
Stop using actions/cache

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -39,16 +39,6 @@ jobs:
         with:
           go-version: '1.20'
 
-      - name: 'Cache dependencies'
-        uses: 'actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09' # ratchet:actions/cache@v3
-        with:
-          path: |-
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}
-          restore-keys: |-
-            ${{ runner.os }}-go-
-            ${{ runner.os }}-go-test-
-
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955' # ratchet:google-github-actions/auth@v0


### PR DESCRIPTION
It doesn't provide substantial gains in the best case, and it's worse that just downloading modules directly in the worst case. Go is smart enough to only download the modules that it needs to build or test.