### PR TITLE
Allow for up to 5s of clock skew drift for jwt validation

### DIFF
--- a/apis/v0/jwt_test.go
+++ b/apis/v0/jwt_test.go
@@ -15,7 +15,9 @@
 package v0
 
 import (
+	context "context"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/abcxyz/pkg/testutil"
@@ -195,6 +197,8 @@ func TestClearRequestor(t *testing.T) {
 func TestGetJustifications(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
+
 	cases := []struct {
 		name   string
 		token  jwt.Token
@@ -242,7 +246,11 @@ func TestGetJustifications(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				parsed, err := jwt.Parse(b, jwt.WithVerify(false))
+				parsed, err := jwt.ParseInsecure(b,
+					jwt.WithContext(ctx),
+					jwt.WithAcceptableSkew(5*time.Second),
+					// WithTypedJustifications(), // explicitly do not use typed claims
+				)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cli/token_test.go
+++ b/pkg/cli/token_test.go
@@ -36,6 +36,8 @@ import (
 func TestNewTokenCmd(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
+
 	goodJVS, _ := testutil.FakeGRPCServer(t, func(s *grpc.Server) {
 		jvspb.RegisterJVSServiceServer(s, &fakeJVS{})
 	})
@@ -159,10 +161,11 @@ func TestNewTokenCmd(t *testing.T) {
 			}
 
 			tokenStr := strings.TrimSpace(stdout)
-			token, err := jwt.ParseString(tokenStr,
-				jwt.WithVerify(false),
-				jwt.WithValidate(false),
-				jvspb.WithTypedJustifications())
+			token, err := jwt.ParseInsecure([]byte(tokenStr),
+				jwt.WithContext(ctx),
+				jwt.WithAcceptableSkew(5*time.Second),
+				jvspb.WithTypedJustifications(),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -140,7 +140,7 @@ func runValidateCmd(cmd *cobra.Command, opts *validateCmdOptions, args []string)
 
 	// Validate token
 	breakglass := false
-	token, err := jvspb.ParseBreakglassToken(opts.token)
+	token, err := jvspb.ParseBreakglassToken(ctx, opts.token)
 	if err != nil {
 		return fmt.Errorf("failed to parse breakglass token: %w", err)
 	}

--- a/pkg/idtoken/idtoken_test.go
+++ b/pkg/idtoken/idtoken_test.go
@@ -99,11 +99,14 @@ func TestIDTokenFromDefaultTokenSource(t *testing.T) {
 // Set env var MANUAL_TEST=true to run the test.
 func TestFromDefaultCredentials(t *testing.T) {
 	t.Parallel()
+
+	ctx := context.Background()
+
 	if os.Getenv("MANUAL_TEST") == "" {
 		t.Skip("Skip manual test; set env var MANUAL_TEST to enable")
 	}
 
-	ts, err := FromDefaultCredentials(context.Background())
+	ts, err := FromDefaultCredentials(ctx)
 	if err != nil {
 		t.Fatalf("failed to get ID token source: %v", err)
 	}
@@ -113,7 +116,10 @@ func TestFromDefaultCredentials(t *testing.T) {
 		t.Fatalf("failed to get ID token: %v", err)
 	}
 
-	if _, err := jwt.Parse([]byte(tk.AccessToken), jwt.WithVerify(false)); err != nil {
+	if _, err := jwt.ParseInsecure([]byte(tk.AccessToken),
+		jwt.WithContext(ctx),
+		jwt.WithAcceptableSkew(5*time.Second),
+	); err != nil {
 		t.Errorf("%q not a valid ID token: %v", tk.AccessToken, err)
 	}
 }

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -285,8 +285,11 @@ func TestCreateToken(t *testing.T) {
 
 			// Parse as a JWT.
 			token, err := jwt.Parse(response,
+				jwt.WithContext(ctx),
 				jwt.WithKey(jwa.ES256, privateKey.Public()),
-				jvspb.WithTypedJustifications())
+				jwt.WithAcceptableSkew(5*time.Second),
+				jvspb.WithTypedJustifications(),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/justification/server.go
+++ b/pkg/justification/server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	grpcmetadata "google.golang.org/grpc/metadata"
@@ -85,7 +86,9 @@ func extractRequestorFromIncomingContext(ctx context.Context) (string, error) {
 	// We intentionally do not validate or verify the token since the upstream
 	// authentication should have taken care of it. In the case of Cloud Run, the
 	// signature is stripped, so we can't even verify if we wanted.
-	t, err := jwt.ParseInsecure([]byte(raw))
+	t, err := jwt.ParseInsecure([]byte(raw),
+		jwt.WithAcceptableSkew(5*time.Second),
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse incoming jwt: %w", err)
 	}

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -241,7 +241,7 @@ func TestJVS(t *testing.T) {
 			}
 
 			// Validate message headers - we have to parse the full envelope for this.
-			message, err := jws.ParseString(resp.Token)
+			message, err := jws.Parse([]byte(resp.Token))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -262,9 +262,12 @@ func TestJVS(t *testing.T) {
 			}
 
 			// Parse as a JWT.
-			token, err := jwt.ParseString(resp.Token,
+			token, err := jwt.Parse([]byte(resp.Token),
+				jwt.WithContext(ctx),
 				jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
-				jvspb.WithTypedJustifications())
+				jwt.WithAcceptableSkew(5*time.Second),
+				jvspb.WithTypedJustifications(),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This addresses an issue where clock skew may exist between calling systems by allowing a 5s grace period for clock skew. This PR also standardizes on passing a context to all jwt validation calls and uses `ParseInsecure` instead of using `WithVerify(false)` and `WithValidate(false)`.

This fixes occasional test flakiness like https://github.com/abcxyz/jvs/actions/runs/4366851958/jobs/7637400639.