### PR TITLE
Return a retryable error when a key version is not ready

### DIFF
--- a/pkg/jvscrypto/cert_action_api_test.go
+++ b/pkg/jvscrypto/cert_action_api_test.go
@@ -75,6 +75,10 @@ func TestCertificateAction(t *testing.T) {
 					Parent:           parent,
 					CryptoKeyVersion: &kmspb.CryptoKeyVersion{},
 				},
+				// Lookup the new version
+				&kmspb.GetCryptoKeyVersionRequest{
+					Name: versionName + "-new",
+				},
 				// Lookup the key again
 				&kmspb.GetCryptoKeyRequest{
 					Name: parent,
@@ -118,6 +122,10 @@ func TestCertificateAction(t *testing.T) {
 				&kmspb.CreateCryptoKeyVersionRequest{
 					Parent:           parent,
 					CryptoKeyVersion: &kmspb.CryptoKeyVersion{},
+				},
+				// Lookup the new version
+				&kmspb.GetCryptoKeyVersionRequest{
+					Name: versionName + "-new",
 				},
 				// Lookup the key again
 				&kmspb.GetCryptoKeyRequest{
@@ -208,6 +216,10 @@ func TestCertificateAction(t *testing.T) {
 					Parent:           parent,
 					CryptoKeyVersion: &kmspb.CryptoKeyVersion{},
 				},
+				// Lookup the new version
+				&kmspb.GetCryptoKeyVersionRequest{
+					Name: versionName + "-new",
+				},
 				// Lookup the key again
 				&kmspb.GetCryptoKeyRequest{
 					Name: parent,
@@ -277,6 +289,10 @@ func TestCertificateAction(t *testing.T) {
 				&kmspb.CreateCryptoKeyVersionRequest{
 					Parent:           parent,
 					CryptoKeyVersion: &kmspb.CryptoKeyVersion{},
+				},
+				// Lookup the new version
+				&kmspb.GetCryptoKeyVersionRequest{
+					Name: versionName + "-new",
 				},
 				// Look up the existing key
 				&kmspb.GetCryptoKeyRequest{

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -306,7 +306,7 @@ func TestPerformActions(t *testing.T) {
 	versionSuffix := "[VERSION]"
 	versionName := fmt.Sprintf("%s/cryptoKeyVersions/%s", parent, versionSuffix)
 
-	tests := []struct {
+	cases := []struct {
 		name             string
 		actions          []*actionTuple
 		priorPrimary     string
@@ -355,6 +355,9 @@ func TestPerformActions(t *testing.T) {
 				&kmspb.CreateCryptoKeyVersionRequest{
 					Parent:           parent,
 					CryptoKeyVersion: &kmspb.CryptoKeyVersion{},
+				},
+				&kmspb.GetCryptoKeyVersionRequest{
+					Name: versionName + "-new",
 				},
 				&kmspb.GetCryptoKeyRequest{
 					Name: parent,
@@ -431,6 +434,9 @@ func TestPerformActions(t *testing.T) {
 					Parent:           parent,
 					CryptoKeyVersion: &kmspb.CryptoKeyVersion{},
 				},
+				&kmspb.GetCryptoKeyVersionRequest{
+					Name: versionName + "-new",
+				},
 				&kmspb.DestroyCryptoKeyVersionRequest{
 					Name: versionName + "2",
 				},
@@ -457,7 +463,7 @@ func TestPerformActions(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
+	for _, tc := range cases {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/testutil/kmsmock.go
+++ b/pkg/testutil/kmsmock.go
@@ -101,7 +101,8 @@ func (s *MockKeyManagementServer) GetCryptoKeyVersion(ctx context.Context, req *
 		return nil, s.Err
 	}
 	return &kmspb.CryptoKeyVersion{
-		Name: req.Name,
+		Name:  req.Name,
+		State: kmspb.CryptoKeyVersion_ENABLED,
 	}, nil
 }
 
@@ -165,7 +166,12 @@ func (s *MockKeyManagementServer) UpdateCryptoKey(ctx context.Context, req *kmsp
 // NewMockKeyManagementServer sets up a mock KMS server with required values for use in testing.
 func NewMockKeyManagementServer(keyName, versionName, primary string) *MockKeyManagementServer {
 	return &MockKeyManagementServer{
-		Resps:       []proto.Message{&kmspb.CryptoKeyVersion{Name: versionName + "-new"}},
+		Resps: []proto.Message{
+			&kmspb.CryptoKeyVersion{
+				Name:  versionName + "-new",
+				State: kmspb.CryptoKeyVersion_ENABLED,
+			},
+		},
 		KeyName:     keyName,
 		VersionName: versionName,
 		Labels:      map[string]string{"primary": primary},


### PR DESCRIPTION
This fixes some flakiness with tests. Even though the tests were in a retry block, none of the returned errors were marked as retryable. As a result, it would always return on the first error.