### PR TITLE
Use the renderer for JSON responses

### DIFF
--- a/pkg/config/crypto_config.go
+++ b/pkg/config/crypto_config.go
@@ -27,6 +27,9 @@ var CryptoConfigVersions = NewVersionList("1")
 
 // CryptoConfig is the full jvs config.
 type CryptoConfig struct {
+	// DevMode controls enables more granular debugging in logs.
+	DevMode bool `env:"DEV_MODE,default=false"`
+
 	// Version is the version of the config.
 	Version string `yaml:"version,omitempty" env:"VERSION,overwrite,default=1"`
 

--- a/pkg/config/public_key_config.go
+++ b/pkg/config/public_key_config.go
@@ -20,6 +20,9 @@ import (
 
 // PublicKeyConfig is the config used for public key hosting.
 type PublicKeyConfig struct {
+	// DevMode controls enables more granular debugging in logs.
+	DevMode bool `env:"DEV_MODE,default=false"`
+
 	// TODO: This is intended to be temporary, and will eventually be retrieved from a persistent external datastore
 	// https://github.com/abcxyz/jvs/issues/17
 	// KeyName format: `projects/*/locations/*/keyRings/*/cryptoKeys/*`


### PR DESCRIPTION
This will ensure consistent responses and content types. There's one place where we still write directly to the http.ResponseWriter, and that's because the cacher caches the rendered JSON response.

Closes https://github.com/abcxyz/jvs/issues/224