### PR TITLE
fix: update doc for jvscli

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,13 +28,13 @@ the same justification server for minting tokens, add the following to your
 `.bashrc` or `.zshrc` file:
 
 ```shell
-export JVSCTL_SERVER_ADDRESS="https://jvs.corp.internal:8080"
+export JVSCTL_SERVER_ADDRESS="jvs.corp.internal:443"
 ```
 
 Similarly, you can set the endpoint for getting the JWKS for verification:
 
 ```shell
-export JVSCTL_JWKS_ENDPOINT="https://keys.corp.internal:8080/.well-known/jwks"
+export JVSCTL_JWKS_ENDPOINT="https://keys.corp.internal/.well-known/jwks"
 ```
 
 For the full list of options that correspond to your release, check the help

--- a/terraform/e2e/variables.tf
+++ b/terraform/e2e/variables.tf
@@ -53,23 +53,23 @@ variable "kms_key_location" {
 variable "jvs_api_service_image" {
   description = "Container image for JVS API service."
   type        = string
-  default     = "gcr.io/cloudrun/hello:latest"
+  default     = "us-docker.pkg.dev/abcxyz-artifacts/docker-images/jvs-justification:0.0.4"
 }
 
 variable "jvs_ui_service_image" {
   description = "Container image for JVS UI service."
   type        = string
-  default     = "gcr.io/cloudrun/hello:latest"
+  default     = "us-docker.pkg.dev/abcxyz-artifacts/docker-images/jvs-ui:0.0.4"
 }
 
 variable "jvs_cert_rotator_service_image" {
   description = "Container image for JVS cert rotator service."
   type        = string
-  default     = "gcr.io/cloudrun/hello:latest"
+  default     = "us-docker.pkg.dev/abcxyz-artifacts/docker-images/jvs-cert-rotation:0.0.4"
 }
 
 variable "jvs_public_key_service_image" {
   description = "Container image for JVS public key service."
   type        = string
-  default     = "gcr.io/cloudrun/hello:latest"
+  default     = "us-docker.pkg.dev/abcxyz-artifacts/docker-images/jvs-public-key:0.0.4"
 }


### PR DESCRIPTION
JVSCTL_SERVER_ADDRESS doesn't need the `https://` prefix. And the port by default is 443.
JVSCTL_JWKS_ENDPOINT doesn't the port number. 