### PR TITLE
Fix a bug where manual-cert-actions could not start

### DIFF
--- a/cmd/manual-cert-actions/main.go
+++ b/cmd/manual-cert-actions/main.go
@@ -65,7 +65,7 @@ func realMain(ctx context.Context) error {
 	))
 
 	var cfg config.CryptoConfig
-	if err := cfgloader.Load(ctx, cfg); err != nil {
+	if err := cfgloader.Load(ctx, &cfg); err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 


### PR DESCRIPTION
Is this code actively used? If not, maybe deleting it is a better option.

This was added in https://github.com/abcxyz/jvs/pull/79, and I'm not sure whether we should keep it.