### PR TITLE
Move $PORT into config structs

### DIFF
--- a/cmd/cert-rotation/main.go
+++ b/cmd/cert-rotation/main.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -90,7 +89,7 @@ func realMain(ctx context.Context) error {
 	defer kmsClient.Close()
 
 	// Load the config
-	var cfg config.CryptoConfig
+	var cfg config.CertRotationConfig
 	if err := cfgloader.Load(ctx, &cfg); err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -114,16 +113,9 @@ func realMain(ctx context.Context) error {
 		},
 	))
 
-	// Determine port for HTTP service.
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-		logger.Debugw("defaulting to port ", "port", port)
-	}
-
 	// Create the server and listen in a goroutine.
 	server := &http.Server{
-		Addr:              ":" + port,
+		Addr:              ":" + cfg.Port,
 		Handler:           mux,
 		ReadHeaderTimeout: 2 * time.Second,
 	}

--- a/cmd/manual-cert-actions/main.go
+++ b/cmd/manual-cert-actions/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"os/signal"
 	"syscall"
 
@@ -64,7 +63,7 @@ func realMain(ctx context.Context) error {
 		otelgrpc.UnaryServerInterceptor(),
 	))
 
-	var cfg config.CryptoConfig
+	var cfg config.CertRotationConfig
 	if err := cfgloader.Load(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -83,15 +82,9 @@ func realMain(ctx context.Context) error {
 	jvspb.RegisterCertificateActionServiceServer(s, cas)
 	reflection.Register(s)
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-		logger.Debugw("defaulting to port ", "port", port)
-	}
-
-	lis, err := net.Listen("tcp", ":"+port)
+	lis, err := net.Listen("tcp", ":"+cfg.Port)
 	if err != nil {
-		return fmt.Errorf("failed to listen on port %s: %w", port, err)
+		return fmt.Errorf("failed to listen on port %s: %w", cfg.Port, err)
 	}
 
 	// TODO: Do we need a gRPC health check server?

--- a/pkg/config/cert_rotation_config.go
+++ b/pkg/config/cert_rotation_config.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config provides configuration-related files and methods.
+package config
+
+import "github.com/hashicorp/go-multierror"
+
+// CertRotationConfig is a configuration for cert rotation services.
+type CertRotationConfig struct {
+	*CryptoConfig
+
+	// DevMode controls enables more granular debugging in logs.
+	DevMode bool `env:"DEV_MODE,default=false"`
+
+	// Port is the port where the service runs.
+	Port string `env:"PORT,default=8080"`
+}
+
+// Validate checks if the config is valid.
+func (c *CertRotationConfig) Validate() error {
+	var merr *multierror.Error
+
+	if err := c.CryptoConfig.Validate(); err != nil {
+		merr = multierror.Append(merr, err)
+	}
+
+	return merr.ErrorOrNil()
+}

--- a/pkg/config/cert_rotation_config_test.go
+++ b/pkg/config/cert_rotation_config_test.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/sethvargo/go-envconfig"
+)
+
+func TestCertRotationConfig_Defaults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var cfg CertRotationConfig
+	if err := envconfig.ProcessWith(ctx, &cfg, envconfig.MapLookuper(nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	want := &CertRotationConfig{
+		DevMode: false,
+		Port:    "8080",
+		CryptoConfig: &CryptoConfig{
+			Version: "1",
+		},
+	}
+
+	if diff := cmp.Diff(want, &cfg); diff != "" {
+		t.Errorf("config with defaults (-want, +got):\n%s", diff)
+	}
+}
+
+func TestCertRotationConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("validates_crypto_config", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &CertRotationConfig{
+			CryptoConfig: &CryptoConfig{
+				GracePeriod: -1 * time.Minute, // must be positive, should fail validation
+			},
+		}
+
+		err := cfg.Validate()
+		if diff := testutil.DiffErrString(err, "grace period must be a positive duration"); diff != "" {
+			t.Errorf(diff)
+		}
+	})
+}

--- a/pkg/jvscrypto/cert_action_api_test.go
+++ b/pkg/jvscrypto/cert_action_api_test.go
@@ -343,7 +343,9 @@ func TestCertificateAction(t *testing.T) {
 			}
 
 			service := &CertificateActionService{
-				Handler:   NewRotationHandler(ctx, c, &config.CryptoConfig{}),
+				Handler: NewRotationHandler(ctx, c, &config.CertRotationConfig{
+					CryptoConfig: &config.CryptoConfig{},
+				}),
 				KMSClient: c,
 			}
 

--- a/pkg/jvscrypto/rotation_handler.go
+++ b/pkg/jvscrypto/rotation_handler.go
@@ -36,13 +36,13 @@ import (
 // based off a provided configuration.
 type RotationHandler struct {
 	kmsClient *kms.KeyManagementClient
-	config    *config.CryptoConfig
+	config    *config.CertRotationConfig
 }
 
 // NewRotationHandler creates a handler for rotating keys.
-func NewRotationHandler(ctx context.Context, kmsClient *kms.KeyManagementClient, cfg *config.CryptoConfig) *RotationHandler {
+func NewRotationHandler(ctx context.Context, kmsClient *kms.KeyManagementClient, cfg *config.CertRotationConfig) *RotationHandler {
 	if cfg == nil {
-		cfg = &config.CryptoConfig{}
+		cfg = &config.CertRotationConfig{}
 	}
 
 	return &RotationHandler{

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -113,11 +113,13 @@ func TestDetermineActions(t *testing.T) {
 		t.Error("Couldn't parse propagation delay")
 	}
 
-	handler := NewRotationHandler(ctx, nil, &config.CryptoConfig{
-		KeyTTL:           keyTTL,
-		GracePeriod:      gracePeriod,
-		DisabledPeriod:   disablePeriod,
-		PropagationDelay: propagationDelay,
+	handler := NewRotationHandler(ctx, nil, &config.CertRotationConfig{
+		CryptoConfig: &config.CryptoConfig{
+			KeyTTL:           keyTTL,
+			GracePeriod:      gracePeriod,
+			DisabledPeriod:   disablePeriod,
+			PropagationDelay: propagationDelay,
+		},
 	})
 
 	curTime := time.Unix(100*60*60*24, 0) // 100 days after start

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -331,13 +331,15 @@ func TestRotator(t *testing.T) {
 
 	kmsClient, keyName := testSetupRotator(ctx, t)
 
-	cfg := &config.CryptoConfig{
-		Version:          "1",
-		KeyTTL:           7 * time.Second,
-		GracePeriod:      2 * time.Second, // rotate after 5 seconds
-		PropagationDelay: time.Second,
-		DisabledPeriod:   time.Second,
-		KeyNames:         []string{keyName},
+	cfg := &config.CertRotationConfig{
+		CryptoConfig: &config.CryptoConfig{
+			Version:          "1",
+			KeyTTL:           7 * time.Second,
+			GracePeriod:      2 * time.Second, // rotate after 5 seconds
+			PropagationDelay: time.Second,
+			DisabledPeriod:   time.Second,
+			KeyNames:         []string{keyName},
+		},
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatal(err)
@@ -418,13 +420,15 @@ func TestRotator_EdgeCases(t *testing.T) {
 
 	kmsClient, keyName := testSetupRotator(ctx, t)
 
-	cfg := &config.CryptoConfig{
-		Version:          "1",
-		KeyTTL:           99 * time.Hour,
-		GracePeriod:      time.Second,
-		PropagationDelay: time.Second,
-		DisabledPeriod:   time.Second,
-		KeyNames:         []string{keyName},
+	cfg := &config.CertRotationConfig{
+		CryptoConfig: &config.CryptoConfig{
+			Version:          "1",
+			KeyTTL:           99 * time.Hour,
+			GracePeriod:      time.Second,
+			PropagationDelay: time.Second,
+			DisabledPeriod:   time.Second,
+			KeyNames:         []string{keyName},
+		},
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatal(err)
@@ -541,13 +545,15 @@ func TestCertActions(t *testing.T) {
 
 	kmsClient, keyName := testSetupRotator(ctx, t)
 
-	cfg := &config.CryptoConfig{
-		Version:          "1",
-		KeyTTL:           7 * time.Second,
-		GracePeriod:      2 * time.Second, // rotate after 5 seconds
-		PropagationDelay: time.Second,
-		DisabledPeriod:   time.Second,
-		KeyNames:         []string{keyName},
+	cfg := &config.CertRotationConfig{
+		CryptoConfig: &config.CryptoConfig{
+			Version:          "1",
+			KeyTTL:           7 * time.Second,
+			GracePeriod:      2 * time.Second, // rotate after 5 seconds
+			PropagationDelay: time.Second,
+			DisabledPeriod:   time.Second,
+			KeyNames:         []string{keyName},
+		},
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This requires introducing a new config structure for cert rotation, because it previously just called `os.Getenv`. From a user-facing perspective, this has no impact. Both envconfig and `os.Getenv` read from the environment. This is an internal-only change that will give us more flexibility over port mapping in the future.