### PR TITLE
update prober cloud run job default service account

### DIFF
--- a/terraform/e2e/main.tf
+++ b/terraform/e2e/main.tf
@@ -88,5 +88,5 @@ module "jvs_monitoring" {
   prober_jvs_api_address         = "${var.jvs_api_domain}:443"
   prober_jvs_public_key_endpoint = "https://${var.jvs_api_domain}/.well-known/jwks"
   jvs_prober_image               = var.jvs_prober_image
-  prober_audience                = module.jvs_services.jvs_api_service_url
+  prober_audience                = var.prober_audience
 }

--- a/terraform/e2e/main.tf
+++ b/terraform/e2e/main.tf
@@ -88,5 +88,5 @@ module "jvs_monitoring" {
   prober_jvs_api_address         = "${var.jvs_api_domain}:443"
   prober_jvs_public_key_endpoint = "https://${var.jvs_api_domain}/.well-known/jwks"
   jvs_prober_image               = var.jvs_prober_image
-  prober_audience                = var.prober_audience
+  prober_audience                = module.jvs_services.jvs_api_service_url
 }

--- a/terraform/modules/monitoring/prober.tf
+++ b/terraform/modules/monitoring/prober.tf
@@ -44,6 +44,7 @@ resource "google_cloud_run_v2_job" "jvs_prober" {
           value = var.prober_audience
         }
       }
+      service_account = resource.google_service_account.prober_service_account.email
     }
   }
 

--- a/terraform/modules/monitoring/prober.tf
+++ b/terraform/modules/monitoring/prober.tf
@@ -64,13 +64,10 @@ resource "google_service_account" "prober_service_account" {
   display_name = "Prober Service Account"
 }
 
-#Grant jvs-prober cloud run invoker role.
-resource "google_cloud_run_v2_job_iam_member" "cloudrun_invoker" {
-  project = resource.google_cloud_run_v2_job.jvs_prober.project
+# #Grant jvs-prober cloud run invoker role.
+resource "google_project_iam_member" "cloudrun_invoker" {
+  project = var.project_id
 
-  location = resource.google_cloud_run_v2_job.jvs_prober.location
-
-  name   = resource.google_cloud_run_v2_job.jvs_prober.name
   role   = "roles/run.invoker"
   member = resource.google_service_account.prober_service_account.member
 }


### PR DESCRIPTION
Update prober cloud run job's default service account to use it's dedicated service account. Also, updated the audience to use api-service's url. 