### PR TITLE
Fix: update prober alerting policy

### DIFF
--- a/terraform/modules/monitoring/prober.tf
+++ b/terraform/modules/monitoring/prober.tf
@@ -112,14 +112,14 @@ resource "google_monitoring_alert_policy" "prober_service_failed_number_exceed_t
   # 1. The metric is completed_execution_count
   # 2. The metrics is applied to jvs-prober
   # 3. Only count on failed jobs.
-  # 4. When the failed jobs exceed the threshold,
-  #    alert will be triggered.
+  # 4. When the number of succeeded jobs below
+  #    the threshold, alert will be triggered.
   conditions {
     display_name = "Too many failed JVS probes"
     condition_threshold {
-      filter          = "metric.type=\"run.googleapis.com/job/completed_execution_count\" resource.type=\"cloud_run_job\" resource.label.\"job_name\"=\"${resource.google_cloud_run_v2_job.jvs_prober.name}\" AND metric.label.\"result\"=\"failed\""
+      filter          = "metric.type=\"run.googleapis.com/job/completed_execution_count\" resource.type=\"cloud_run_job\" resource.label.\"job_name\"=\"${resource.google_cloud_run_v2_job.jvs_prober.name}\" AND metric.label.\"result\"=\"succeeded\""
       duration        = "0s"
-      comparison      = "COMPARISON_GT"
+      comparison      = "COMPARISON_LT"
       threshold_value = var.prober_alert_threshold
       aggregations {
         alignment_period   = var.prober_alert_align_window_size_in_seconds

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -132,6 +132,6 @@ variable "prober_alert_align_window_size_in_seconds" {
 
 variable "prober_alert_threshold" {
   type        = number
-  description = "Send alert for Prober-Service when the number of failed prober runs exceeds the threshold."
-  default     = 4
+  description = "Send alert for Prober-Service when the number of succeeded prober runs below the threshold."
+  default     = 5
 }


### PR DESCRIPTION
previously, the policy is `more than X fails in Y mins`, now it's `less than X success in Y mins`, this help covers cases like cloud scheduler is down or cloud run job is down.