### PR TITLE
Fix: Move some jvsctl commands to token subcommand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,5 +54,5 @@ If you installed JVS using the provided Terraform module as described in the
 authentication. E.g.
 
 ```sh
-jvsctl token --auth-token $(gcloud auth print-identity-token) -e "just testing"
+jvsctl token validate --auth-token $(gcloud auth print-identity-token) -e "just testing"
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,5 +54,5 @@ If you installed JVS using the provided Terraform module as described in the
 authentication. E.g.
 
 ```sh
-jvsctl token validate --auth-token $(gcloud auth print-identity-token) -e "just testing"
+jvsctl token create --auth-token $(gcloud auth print-identity-token) -e "just testing"
 ```

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -69,7 +69,18 @@ var rootCmd = func() cli.Command {
 				}
 			},
 			"token": func() cli.Command {
-				return &TokenCommand{}
+				return &cli.RootCommand{
+					Name:        "token",
+					Description: "Perform token operations",
+					Commands: map[string]cli.CommandFactory{
+						"create": func() cli.Command {
+							return &TokenCommand{}
+						},
+						"validate": func() cli.Command {
+							return &ValidateCommand{}
+						},
+					},
+				}
 			},
 			"ui": func() cli.Command {
 				return &cli.RootCommand{
@@ -81,9 +92,6 @@ var rootCmd = func() cli.Command {
 						},
 					},
 				}
-			},
-			"validate": func() cli.Command {
-				return &ValidateCommand{}
 			},
 		},
 	}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -28,9 +28,8 @@ Usage: jvsctl COMMAND
   api           Perform API operations
   public-key    Perform public-key operations
   rotation      Perform rotation operations
-  token         Generate a justification token
+  token         Perform token operations
   ui            Perform ui operations
-  validate      Validate the input token
 `
 
 	cmd := rootCmd()

--- a/pkg/cli/token.go
+++ b/pkg/cli/token.go
@@ -71,19 +71,19 @@ Usage: {{ COMMAND }} [options]
 
   Generate a token with a 30min ttl:
 
-      jvsctl token \
+      jvsctl token create \
         -explanation "issues/12345" \
         -ttl "30m"
 
   Generate a token with custom audiences:
 
-      jvsctl token \
+      jvsctl token create \
         -explanation "access production" \
         -audiences "my.service.dev"
 
   Generate a breakglass token:
 
-      jvsctl token \
+      jvsctl token create \
         -explanation "everything is broken" \
         -breakglass
 `

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -54,7 +54,7 @@ Usage: {{ COMMAND }} [options]
 
   Validate the justification token string:
 
-      jvsctl validate -token "example token string"
+      jvsctl token validate -token "example token string"
 
   Validate the justification token read from pipe:
 

--- a/prober/prober.sh
+++ b/prober/prober.sh
@@ -4,6 +4,6 @@ set -eEuo pipefail
 
 ID_TOKEN=$(curl -sf "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=$AUDIENCE" -H "Metadata-Flavor: Google")
 
-./jvsctl token --auth-token $ID_TOKEN -e "jvs_prober" > jvs_token
+./jvsctl token create --auth-token $ID_TOKEN -e "jvs_prober" > jvs_token
 
-cat jvs_token | ./jvsctl validate --token -
+cat jvs_token | ./jvsctl token validate --token -


### PR DESCRIPTION
Move create and validate to token subcommand.
Fix: #246 