### PR TITLE
Cleanup: rename token subcommand files

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -72,10 +72,10 @@ var rootCmd = func() cli.Command {
 					Description: "Perform token operations",
 					Commands: map[string]cli.CommandFactory{
 						"create": func() cli.Command {
-							return &TokenCommand{}
+							return &TokenCreateCommand{}
 						},
 						"validate": func() cli.Command {
-							return &ValidateCommand{}
+							return &TokenValidateCommand{}
 						},
 					},
 				}

--- a/pkg/cli/token_create.go
+++ b/pkg/cli/token_create.go
@@ -35,9 +35,9 @@ import (
 	"github.com/abcxyz/pkg/cli"
 )
 
-var _ cli.Command = (*TokenCommand)(nil)
+var _ cli.Command = (*TokenCreateCommand)(nil)
 
-type TokenCommand struct {
+type TokenCreateCommand struct {
 	cli.BaseCommand
 
 	flagAudiences   []string
@@ -58,11 +58,11 @@ type TokenCommand struct {
 	flagNowUnix int64
 }
 
-func (c *TokenCommand) Desc() string {
+func (c *TokenCreateCommand) Desc() string {
 	return `Generate a justification token`
 }
 
-func (c *TokenCommand) Help() string {
+func (c *TokenCreateCommand) Help() string {
 	return `
 Usage: {{ COMMAND }} [options]
 
@@ -89,7 +89,7 @@ Usage: {{ COMMAND }} [options]
 `
 }
 
-func (c *TokenCommand) Flags() *cli.FlagSet {
+func (c *TokenCreateCommand) Flags() *cli.FlagSet {
 	set := cli.NewFlagSet()
 
 	// Command options
@@ -175,7 +175,7 @@ func (c *TokenCommand) Flags() *cli.FlagSet {
 	return set
 }
 
-func (c *TokenCommand) Run(ctx context.Context, args []string) error {
+func (c *TokenCreateCommand) Run(ctx context.Context, args []string) error {
 	f := c.Flags()
 	if err := f.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)
@@ -280,7 +280,7 @@ func callOptions(ctx context.Context, authToken string) ([]grpc.CallOption, erro
 
 // breakglassToken creates a new breakglass token from the CLI flags. See
 // [jvspb.CreateBreakglassToken] for more information.
-func (c *TokenCommand) breakglassToken(ctx context.Context) (string, error) {
+func (c *TokenCreateCommand) breakglassToken(ctx context.Context) (string, error) {
 	now := time.Unix(c.flagNowUnix, 0)
 	id := uuid.New().String()
 	exp := now.Add(c.flagTTL)

--- a/pkg/cli/token_create_test.go
+++ b/pkg/cli/token_create_test.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func TestTokenCommand(t *testing.T) {
+func TestTokenCreateCommand(t *testing.T) {
 	t.Parallel()
 
 	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
@@ -142,7 +142,7 @@ func TestTokenCommand(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var cmd TokenCommand
+			var cmd TokenCreateCommand
 			_, stdout, _ := cmd.Pipe()
 
 			args := append([]string{

--- a/pkg/cli/token_validate.go
+++ b/pkg/cli/token_validate.go
@@ -29,9 +29,9 @@ import (
 // cacheTimeout is required for creating jvs client via jvs config, it is not really used since cache is expired when CLI exits.
 const cacheTimeout = 5 * time.Minute
 
-var _ cli.Command = (*ValidateCommand)(nil)
+var _ cli.Command = (*TokenValidateCommand)(nil)
 
-type ValidateCommand struct {
+type TokenValidateCommand struct {
 	cli.BaseCommand
 
 	flagToken        string
@@ -40,11 +40,11 @@ type ValidateCommand struct {
 	flagFormat       string
 }
 
-func (c *ValidateCommand) Desc() string {
+func (c *TokenValidateCommand) Desc() string {
 	return `Validate the input token`
 }
 
-func (c *ValidateCommand) Help() string {
+func (c *TokenValidateCommand) Help() string {
 	return `
 Usage: {{ COMMAND }} [options]
 
@@ -62,7 +62,7 @@ Usage: {{ COMMAND }} [options]
 `
 }
 
-func (c *ValidateCommand) Flags() *cli.FlagSet {
+func (c *TokenValidateCommand) Flags() *cli.FlagSet {
 	set := cli.NewFlagSet()
 
 	// Command options
@@ -108,7 +108,7 @@ func (c *ValidateCommand) Flags() *cli.FlagSet {
 	return set
 }
 
-func (c *ValidateCommand) Run(ctx context.Context, args []string) error {
+func (c *TokenValidateCommand) Run(ctx context.Context, args []string) error {
 	f := c.Flags()
 	if err := f.Parse(args); err != nil {
 		return fmt.Errorf("failed to parse flags: %w", err)

--- a/pkg/cli/token_validate_test.go
+++ b/pkg/cli/token_validate_test.go
@@ -259,7 +259,7 @@ claims:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var cmd ValidateCommand
+			var cmd TokenValidateCommand
 			stdin, stdout, _ := cmd.Pipe()
 
 			// Write stdin if given


### PR DESCRIPTION
* Rename token subcommand files
* Rename struct accordingly
* Fix: #246 