### PR TITLE
Adjust a bunch of go-plugin implementation details to resolve plugin loading exceptions

### DIFF
--- a/apis/v0/plugin_interface.go
+++ b/apis/v0/plugin_interface.go
@@ -42,7 +42,8 @@ var Handshake = plugin.HandshakeConfig{
 // PluginMap is the map of plugins we can dispense.
 var PluginMap = map[string]plugin.Plugin{
 	// Due to [dispense name check], the name need to be consistent with the plugin name.
-	// https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110
+	//
+	// [dispense name check]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110
 	"jira": &ValidatorPlugin{},
 }
 

--- a/apis/v0/plugin_interface.go
+++ b/apis/v0/plugin_interface.go
@@ -39,14 +39,6 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: handshakeCookieValue,
 }
 
-// PluginMap is the map of plugins we can dispense.
-var PluginMap = map[string]plugin.Plugin{
-	// Due to [dispense name check], the name need to be consistent with the plugin name.
-	//
-	// [dispense name check]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110
-	"jira": &ValidatorPlugin{},
-}
-
 // The interface we are exposing as a plugin.
 type Validator interface {
 	Validate(context.Context, *ValidateJustificationRequest) (*ValidateJustificationResponse, error)

--- a/apis/v0/plugin_interface.go
+++ b/apis/v0/plugin_interface.go
@@ -39,6 +39,11 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: handshakeCookieValue,
 }
 
+// PluginMap is the map of plugins we can dispense.
+var PluginMap = map[string]plugin.Plugin{
+	"jvs-plugin-jira": &ValidatorPlugin{},
+}
+
 // The interface we are exposing as a plugin.
 type Validator interface {
 	Validate(context.Context, *ValidateJustificationRequest) (*ValidateJustificationResponse, error)

--- a/apis/v0/plugin_interface.go
+++ b/apis/v0/plugin_interface.go
@@ -44,7 +44,7 @@ type Validator interface {
 	Validate(context.Context, *ValidateJustificationRequest) (*ValidateJustificationResponse, error)
 }
 
-// This is the implementation of [plugin.GRPCPlugin] so we can serve/consume this.
+// ValidatorPlugin implements [plugin.GRPCPlugin].
 //
 // [plugin.GRPCPlugin]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/plugin.go#L36
 type ValidatorPlugin struct {
@@ -55,14 +55,17 @@ type ValidatorPlugin struct {
 	Impl Validator
 }
 
-// Due to [type check], ValidatorPlugin need to implement the following interface.
+// GRPCServer is required by [plugin.GRPCPlugin].
 //
-// [type check]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/server.go#L191
+// [plugin.GRPCPlugin]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/plugin.go#L36
 func (p *ValidatorPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
 	RegisterJVSPluginServer(s, &PluginServer{Impl: p.Impl})
 	return nil
 }
 
+// GRPCClient is required by [plugin.GRPCPlugin].
+//
+// [plugin.GRPCPlugin]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/plugin.go#L36
 func (p *ValidatorPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	return &PluginClient{client: NewJVSPluginClient(c)}, nil
 }

--- a/pkg/plugin/plugin_manager.go
+++ b/pkg/plugin/plugin_manager.go
@@ -51,8 +51,11 @@ func LoadPlugins(dir string) (map[string]jvspb.Validator, *multicloser.Closer, e
 
 		// Enable the plugin.
 		pluginClient := plugin.NewClient(&plugin.ClientConfig{
-			HandshakeConfig:  jvspb.Handshake,
-			Cmd:              exec.Command(path),
+			HandshakeConfig: jvspb.Handshake,
+			// This field need to be set otherwise exception will be thrown from
+			// https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/client.go#L909
+			Plugins:          jvspb.PluginMap,
+			Cmd:              exec.Command(path, "server"),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		})
 		closer = multicloser.Append(closer, pluginClient.Kill)

--- a/pkg/plugin/plugin_manager.go
+++ b/pkg/plugin/plugin_manager.go
@@ -31,6 +31,14 @@ const (
 	PluginGlob = "jvs-plugin-*"
 )
 
+// pluginMap is the map of plugins we can dispense.
+var pluginMap = map[string]plugin.Plugin{
+	// Due to [dispense name check], the name need to be consistent with the plugin name.
+	//
+	// [dispense name check]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110
+	"jira": &jvspb.ValidatorPlugin{},
+}
+
 // LoadPlugins loads plugins in the dir and put them into the Validator interface.
 func LoadPlugins(dir string) (map[string]jvspb.Validator, *multicloser.Closer, error) {
 	validators := make(map[string]jvspb.Validator)
@@ -54,7 +62,7 @@ func LoadPlugins(dir string) (map[string]jvspb.Validator, *multicloser.Closer, e
 			HandshakeConfig: jvspb.Handshake,
 			// Plugins field need to be set otherwise exception will be thrown from
 			// https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/client.go#L909
-			Plugins:          jvspb.PluginMap,
+			Plugins:          pluginMap,
 			Cmd:              exec.Command(path),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		})

--- a/pkg/plugin/plugin_manager.go
+++ b/pkg/plugin/plugin_manager.go
@@ -55,9 +55,6 @@ func LoadPlugins(dir string) (map[string]jvspb.Validator, *multicloser.Closer, e
 			// Plugins field need to be set otherwise exception will be thrown from
 			// https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/client.go#L909
 			Plugins: map[string]plugin.Plugin{
-				// Due to [dispense name check], the name need to be consistent with the plugin name.
-				//
-				// [dispense name check]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110
 				name: &jvspb.ValidatorPlugin{},
 			},
 			Cmd:              exec.Command(path),

--- a/pkg/plugin/plugin_manager.go
+++ b/pkg/plugin/plugin_manager.go
@@ -31,14 +31,6 @@ const (
 	PluginGlob = "jvs-plugin-*"
 )
 
-// pluginMap is the map of plugins we can dispense.
-var pluginMap = map[string]plugin.Plugin{
-	// Due to [dispense name check], the name need to be consistent with the plugin name.
-	//
-	// [dispense name check]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110
-	"jira": &jvspb.ValidatorPlugin{},
-}
-
 // LoadPlugins loads plugins in the dir and put them into the Validator interface.
 func LoadPlugins(dir string) (map[string]jvspb.Validator, *multicloser.Closer, error) {
 	validators := make(map[string]jvspb.Validator)
@@ -62,7 +54,12 @@ func LoadPlugins(dir string) (map[string]jvspb.Validator, *multicloser.Closer, e
 			HandshakeConfig: jvspb.Handshake,
 			// Plugins field need to be set otherwise exception will be thrown from
 			// https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/client.go#L909
-			Plugins:          pluginMap,
+			Plugins: map[string]plugin.Plugin{
+				// Due to [dispense name check], the name need to be consistent with the plugin name.
+				//
+				// [dispense name check]: https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110
+				name: &jvspb.ValidatorPlugin{},
+			},
 			Cmd:              exec.Command(path),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		})

--- a/pkg/plugin/plugin_manager.go
+++ b/pkg/plugin/plugin_manager.go
@@ -52,10 +52,10 @@ func LoadPlugins(dir string) (map[string]jvspb.Validator, *multicloser.Closer, e
 		// Enable the plugin.
 		pluginClient := plugin.NewClient(&plugin.ClientConfig{
 			HandshakeConfig: jvspb.Handshake,
-			// This field need to be set otherwise exception will be thrown from
+			// Plugins field need to be set otherwise exception will be thrown from
 			// https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/client.go#L909
 			Plugins:          jvspb.PluginMap,
-			Cmd:              exec.Command(path, "server"),
+			Cmd:              exec.Command(path),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		})
 		closer = multicloser.Append(closer, pluginClient.Kill)


### PR DESCRIPTION
Specifically fix the following three exceptions while loading the plugins

- plugin.ClientConfig.Plugins field need to be set otherwise exception will be thrown from https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/client.go#L909
- Due to [type check](https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/server.go#L191), ValidatorPlugin need to implement [plugin.GRPCPlugin](https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/plugin.go#L36).
- Due to [dispense name check](https://github.com/hashicorp/go-plugin/blob/a88a423a8813d0b26c8e3219f71b0f30447b5d2e/grpc_client.go#L110), the name need to be consistent with the plugin name.

Link to: #276 