### PR TITLE
cleanup: make explanation the default validator

### DIFF
--- a/apis/v0/plugin.go
+++ b/apis/v0/plugin.go
@@ -25,7 +25,16 @@ import (
 const (
 	handshakeCookieKey   = "JVS_PLUGIN"
 	handshakeCookieValue = "cc400ef1c6e74ee20be491c6013ae2120fb04c11703d05fbbf18dbb2e5e0"
+
+	// DefaultJustificationCategory is the default justification category
+	// supported. An "explanation" justification represents a manual free text
+	// reason from the requester.
+	DefaultJustificationCategory = "explanation"
 )
+
+// DefaultJustificationValidator is the [Validator] for the
+// [DefaultJustificationCategory].
+var DefaultJustificationValidator = &ExplanationValidator{}
 
 // Handshake is a common handshake that is shared by plugin and host.
 // handshakeConfigs are used to just do a basic handshake between
@@ -42,6 +51,22 @@ var Handshake = plugin.HandshakeConfig{
 // The interface we are exposing as a plugin.
 type Validator interface {
 	Validate(context.Context, *ValidateJustificationRequest) (*ValidateJustificationResponse, error)
+}
+
+// ExplanationValidator is the built-in [Validator] for the "explanation"
+// justifications. An "explanation" justification represents a manual free text
+// reason from the requester.
+type ExplanationValidator struct{}
+
+// Validate only checks if the input is not empty.
+func (v *ExplanationValidator) Validate(_ context.Context, req *ValidateJustificationRequest) (*ValidateJustificationResponse, error) {
+	if req.Justification == nil || req.Justification.Value == "" {
+		return &ValidateJustificationResponse{
+			Valid: false,
+			Error: []string{"explanation cannot be empty"},
+		}, nil
+	}
+	return &ValidateJustificationResponse{Valid: true}, nil
 }
 
 // ValidatorPlugin implements [plugin.GRPCPlugin].

--- a/apis/v0/plugin_test.go
+++ b/apis/v0/plugin_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v0
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestExplanationValidator(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		req      *ValidateJustificationRequest
+		wantResp *ValidateJustificationResponse
+	}{
+		{
+			name: "success",
+			req: &ValidateJustificationRequest{
+				Justification: &Justification{
+					Category: "explanation",
+					Value:    "I have reasons",
+				},
+			},
+			wantResp: &ValidateJustificationResponse{
+				Valid: true,
+			},
+		},
+		{
+			name: "success",
+			req: &ValidateJustificationRequest{
+				Justification: &Justification{
+					Category: "explanation",
+				},
+			},
+			wantResp: &ValidateJustificationResponse{
+				Valid: false,
+				Error: []string{"explanation cannot be empty"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotResp, err := DefaultJustificationValidator.Validate(context.Background(), tc.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.wantResp, gotResp, protocmp.Transform()); diff != "" {
+				t.Errorf("Validation response (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -42,12 +42,6 @@ var ttls = map[string]struct{}{
 
 const defaultTTL = "15m"
 
-var categories = map[string]struct{}{
-	"explanation": {},
-}
-
-const defaultCategory = "explanation"
-
 // Controller manages use of the renderer in the http handler.
 type Controller struct {
 	h                   *renderer.Renderer
@@ -99,6 +93,7 @@ type ErrorDetails struct {
 const iapHeaderName = "x-goog-authenticated-user-email"
 
 func New(h *renderer.Renderer, p *justification.Processor, allowlist []string) *Controller {
+	categories := make(map[string]struct{})
 	for v := range p.Validators() {
 		categories[v] = struct{}{}
 	}
@@ -139,7 +134,7 @@ func (c *Controller) handlePopupGet(w http.ResponseWriter, r *http.Request) {
 
 	// set some defaults for the form
 	if formDetails.Category == "" {
-		formDetails.Category = defaultCategory
+		formDetails.Category = jvspb.DefaultJustificationCategory
 	}
 	if formDetails.TTL == "" {
 		formDetails.TTL = defaultTTL

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -314,7 +314,7 @@ func TestValidateForm(t *testing.T) {
 		{
 			name: "no_input_reason",
 			detail: FormDetails{
-				Category: defaultCategory,
+				Category: jvspb.DefaultJustificationCategory,
 				Reason:   "",
 				TTL:      defaultTTL,
 			},
@@ -323,7 +323,7 @@ func TestValidateForm(t *testing.T) {
 		{
 			name: "no_input_ttl",
 			detail: FormDetails{
-				Category: defaultCategory,
+				Category: jvspb.DefaultJustificationCategory,
 				Reason:   "reason",
 				TTL:      "",
 			},

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -138,6 +138,18 @@ func TestCreateToken(t *testing.T) {
 			wantErr: "failed to validate request",
 		},
 		{
+			name: "justification_explanation_empty",
+			request: &jvspb.CreateJustificationRequest{
+				Justifications: []*jvspb.Justification{
+					{
+						Category: "explanation",
+					},
+				},
+				Ttl: durationpb.New(3600 * time.Second),
+			},
+			wantErr: "failed to validate request: failed validation criteria with error [explanation cannot be empty] and warning []",
+		},
+		{
 			name: "no_ttl",
 			request: &jvspb.CreateJustificationRequest{
 				Justifications: []*jvspb.Justification{


### PR DESCRIPTION
Fix: https://github.com/abcxyz/jvs/issues/302

This change helps to get rid of the specially handling of "explanation" category scattered around. It will be more useful when we add display hint to the plugin.