### PR TITLE
feat: handle default category option

### DIFF
--- a/apis/v0/plugin.go
+++ b/apis/v0/plugin.go
@@ -29,7 +29,9 @@ const (
 	// DefaultJustificationCategory is the default justification category
 	// supported. An "explanation" justification represents a manual free text
 	// reason from the requester.
-	DefaultJustificationCategory = "explanation"
+	DefaultJustificationCategory    = "explanation"
+	DefaultJustificationDisplayName = "Explanation"
+	DefaultJustificationHint        = "A justification reason in free-form text."
 )
 
 // DefaultJustificationValidator is the [Validator] for the
@@ -73,8 +75,8 @@ func (v *ExplanationValidator) Validate(_ context.Context, req *ValidateJustific
 // GetUIData retrieves plugin's display data.
 func (v *ExplanationValidator) GetUIData(_ context.Context, req *GetUIDataRequest) (*UIData, error) {
 	return &UIData{
-		DisplayName: "Explanation",
-		Hint:        "A justification reason in free-form text.",
+		DisplayName: DefaultJustificationDisplayName,
+		Hint:        DefaultJustificationHint,
 	}, nil
 }
 

--- a/apis/v0/plugin_test.go
+++ b/apis/v0/plugin_test.go
@@ -86,8 +86,8 @@ func TestGetUIDataInValidator(t *testing.T) {
 			name: "success",
 			req:  &GetUIDataRequest{},
 			wantResp: &UIData{
-				DisplayName: DefaultJustificationDisplayName,
-				Hint:        DefaultJustificationHint,
+				DisplayName: "Explanation",
+				Hint:        "A justification reason in free-form text.",
 			},
 		},
 	}

--- a/apis/v0/plugin_test.go
+++ b/apis/v0/plugin_test.go
@@ -86,8 +86,8 @@ func TestGetUIDataInValidator(t *testing.T) {
 			name: "success",
 			req:  &GetUIDataRequest{},
 			wantResp: &UIData{
-				DisplayName: "Explanation",
-				Hint:        "A justification reason in free-form text.",
+				DisplayName: DefaultJustificationDisplayName,
+				Hint:        DefaultJustificationHint,
 			},
 		},
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -301,7 +302,7 @@ func (c *Controller) getFormDetails(r *http.Request) (*FormDetails, error) {
 	return &FormDetails{
 		WindowName:  r.FormValue("windowname"),
 		Origin:      r.FormValue("origin"),
-		Category:    r.FormValue("category"),
+		Category:    c.getCategory(),
 		Reason:      r.FormValue("reason"),
 		UserEmail:   email,
 		TTL:         r.FormValue("ttl"),
@@ -354,5 +355,22 @@ func catagoriesDisplayData(ctx context.Context, validators map[string]jvspb.Vali
 		}
 		displayData[k] = d
 	}
+
+	// In case there are additional category options available, we aim to hide the default option from users.
+	if len(displayData) > 1 {
+		delete(displayData, jvspb.DefaultJustificationCategory)
+	}
+
 	return displayData, nil
+}
+
+// The category with the lowest alphabetical value will be selected.
+func (c *Controller) getCategory() string {
+	// Due to the presence of the DefaultJustificationCategory, the categoryDisplayData list cannot be empty.
+	keys := make([]string, 0, len(c.categoryDisplayData))
+	for key := range c.categoryDisplayData {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys[0]
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -504,6 +504,35 @@ func TestGetCatagoriesDisplayData(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "success_with_default_validator_hidden",
+			validators: map[string]jvspb.Validator{
+				"jira": &mockValidator{
+					Valid:       true,
+					DisplayName: "Jira issue key",
+					Hint:        "Jira Issue key under JVS project",
+				},
+				jvspb.DefaultJustificationCategory: jvspb.DefaultJustificationValidator,
+			},
+			wantRes: map[string]*jvspb.UIData{
+				"jira": {
+					DisplayName: "Jira issue key",
+					Hint:        "Jira Issue key under JVS project",
+				},
+			},
+		},
+		{
+			name: "success_with_default_validator_only",
+			validators: map[string]jvspb.Validator{
+				jvspb.DefaultJustificationCategory: jvspb.DefaultJustificationValidator,
+			},
+			wantRes: map[string]*jvspb.UIData{
+				jvspb.DefaultJustificationCategory: {
+					DisplayName: jvspb.DefaultJustificationDisplayName,
+					Hint:        jvspb.DefaultJustificationHint,
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
fix: #327 

- If there are multiple category options("Jira Issue Key", "Github" ...), then we don't want to show the default category option ("Explanation"). 
- If not, we can show the default category option. 