### PR TITLE
Update validation error logging

### DIFF
--- a/pkg/justification/processor.go
+++ b/pkg/justification/processor.go
@@ -145,7 +145,6 @@ func (p *Processor) getPrimarySigner(ctx context.Context) (*signerWithID, error)
 	}, nil
 }
 
-// TODO: Each category should have its own validator struct, with a shared interface.
 // runValidations is an internal helper function that validates requests.
 // If any errors occur during validation, it returns a standard internal error message with codes.Internal.
 // If the request fails validation, it returns full error messages with codes.InvalidArgument.

--- a/pkg/justification/processor.go
+++ b/pkg/justification/processor.go
@@ -93,8 +93,7 @@ func (p *Processor) CreateToken(ctx context.Context, requestor string, req *jvsp
 	logger := logging.FromContext(ctx)
 
 	if err := p.runValidations(ctx, req); err != nil {
-		logger.ErrorContext(ctx, "failed to validate request", "error", err)
-		return nil, status.Errorf(codes.InvalidArgument, "failed to validate request: %s", err)
+		return nil, err
 	}
 
 	token, err := p.createToken(ctx, requestor, req, now)
@@ -147,10 +146,16 @@ func (p *Processor) getPrimarySigner(ctx context.Context) (*signerWithID, error)
 }
 
 // TODO: Each category should have its own validator struct, with a shared interface.
-func (p *Processor) runValidations(ctx context.Context, req *jvspb.CreateJustificationRequest) (merr error) {
+// runValidations is an internal helper function that validates requests.
+// If any errors occur during validation, it returns an error with codes.Internal.
+// If the request fails validation, it returns an error with codes.InvalidArgument.
+func (p *Processor) runValidations(ctx context.Context, req *jvspb.CreateJustificationRequest) error {
+	logger := logging.FromContext(ctx)
 	if len(req.Justifications) < 1 {
-		return fmt.Errorf("no justifications specified")
+		return status.Errorf(codes.InvalidArgument, "failed to validate request: no justifications specified")
 	}
+
+	var validationErr, internalErr error
 
 	var justificationsLength int
 	for _, j := range req.Justifications {
@@ -158,19 +163,19 @@ func (p *Processor) runValidations(ctx context.Context, req *jvspb.CreateJustifi
 
 		v, ok := p.validators[j.Category]
 		if !ok {
-			merr = errors.Join(merr, fmt.Errorf("missing validator for category %q", j.Category))
+			validationErr = errors.Join(validationErr, fmt.Errorf("missing validator for category %q", j.Category))
 			continue
 		}
 		resp, verr := v.Validate(ctx, &jvspb.ValidateJustificationRequest{
 			Justification: j,
 		})
 		if verr != nil {
-			merr = errors.Join(merr, fmt.Errorf("unexpected error from validator %q: %w", j.Category, verr))
+			internalErr = errors.Join(internalErr, fmt.Errorf("unexpected error from validator %q: %w", j.Category, verr))
 			continue
 		}
 
 		if !resp.Valid {
-			merr = errors.Join(merr,
+			validationErr = errors.Join(validationErr,
 				fmt.Errorf("failed validation criteria with error %v and warning %v", resp.Error, resp.Warning))
 		}
 
@@ -180,7 +185,7 @@ func (p *Processor) runValidations(ctx context.Context, req *jvspb.CreateJustifi
 	// This isn't perfect, but it's the easiest place to get "close" to limiting
 	// the size.
 	if got, max := justificationsLength, 4_000; got > max {
-		merr = errors.Join(merr, fmt.Errorf("justification size (%d bytes) must be less than %d bytes",
+		validationErr = errors.Join(validationErr, fmt.Errorf("justification size (%d bytes) must be less than %d bytes",
 			got, max))
 	}
 
@@ -189,11 +194,20 @@ func (p *Processor) runValidations(ctx context.Context, req *jvspb.CreateJustifi
 		audiencesLength += len(v)
 	}
 	if got, max := audiencesLength, 1_000; got > max {
-		merr = errors.Join(merr, fmt.Errorf("audiences size (%d bytes) must be less than %d bytes",
+		validationErr = errors.Join(validationErr, fmt.Errorf("audiences size (%d bytes) must be less than %d bytes",
 			got, max))
 	}
 
-	return
+	if internalErr != nil {
+		logger.ErrorContext(ctx, "internal error during validation", internalErr)
+		return status.Errorf(codes.Internal, "unable to validate request")
+	}
+
+	if validationErr != nil {
+		logger.WarnContext(ctx, "failed to validate token", "error", validationErr)
+		return status.Errorf(codes.InvalidArgument, "failed to validate request: %s", validationErr.Error())
+	}
+	return nil
 }
 
 // createToken is an internal helper for testing that builds an unsigned jwt

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -43,6 +43,8 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -324,7 +326,7 @@ func TestCreateToken(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "failed validation criteria with error [bad explanation] and warning []",
+			wantErr: status.Error(codes.InvalidArgument, "failed to validate request: failed validation criteria with error [bad explanation] and warning []").Error(),
 		},
 		{
 			name: "validator_err",
@@ -342,7 +344,7 @@ func TestCreateToken(t *testing.T) {
 					err: fmt.Errorf("Cannot connect to validator"),
 				},
 			},
-			wantErr: "unable to validate request",
+			wantErr: status.Error(codes.Internal, "unable to validate request").Error(),
 		},
 		{
 			name: "validator_missing_ui_data",
@@ -382,7 +384,7 @@ func TestCreateToken(t *testing.T) {
 				},
 				Ttl: durationpb.New(3600 * time.Second),
 			},
-			wantErr: "missing validator for category \"jira\"",
+			wantErr: status.Error(codes.InvalidArgument, "failed to validate request: category \"jira\" is not supported").Error(),
 		},
 	}
 

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -342,7 +342,7 @@ func TestCreateToken(t *testing.T) {
 					err: fmt.Errorf("Cannot connect to validator"),
 				},
 			},
-			wantErr: "unexpected error from validator \"jira\": Cannot connect to validator",
+			wantErr: "unable to validate request",
 		},
 		{
 			name: "validator_missing_ui_data",


### PR DESCRIPTION
Fix https://github.com/abcxyz/jvs-plugin-jira/issues/48

In `runValidations` method, errors from validation response are joined to `validationErr`, other errors thrown in the process are joined to `internalErr`.
For internal errors, we log them with error severity and only returns a standard internal error message to the user. For validation errors, we log them with warning severity and return the error messages to the user

Validation error page: https://screenshot.googleplex.com/6nVVX2tM8hEfFMX and https://screenshot.googleplex.com/9YNJXeAm6rC635z

Internal error page: https://screenshot.googleplex.com/Me69mo934DcuqeF

Error logs https://screenshot.googleplex.com/5YHzwbPTr9ktEfx