### PR TITLE
fix: change ci module output from id to member

### DIFF
--- a/terraform/ci/outputs.tf
+++ b/terraform/ci/outputs.tf
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-
 output "jvs_api_service_account_email" {
   description = "JVS API service account email."
   value       = module.jvs_common.jvs_api_service_account_email
+}
+
+output "jvs_api_service_account_name" {
+  description = "JVS API service account name."
+  value       = module.jvs_common.jvs_api_service_account_name
 }
 
 output "jvs_api_service_account_member" {
@@ -30,6 +34,11 @@ output "jvs_ui_service_account_email" {
   value       = module.jvs_common.jvs_ui_service_account_email
 }
 
+output "jvs_ui_service_account_name" {
+  description = "JVS UI service account name."
+  value       = module.jvs_common.jvs_ui_service_account_name
+}
+
 output "jvs_ui_service_account_member" {
   description = "JVS UI service account member."
   value       = module.jvs_common.jvs_ui_service_account_member
@@ -40,6 +49,11 @@ output "jvs_cert_rotator_service_account_email" {
   value       = module.jvs_common.jvs_cert_rotator_service_account_email
 }
 
+output "jvs_cert_rotator_service_account_name" {
+  description = "JVS cert rotator service account name."
+  value       = module.jvs_common.jvs_cert_rotator_service_account_name
+}
+
 output "jvs_cert_rotator_service_account_member" {
   description = "JVS cert rotator service account member."
   value       = module.jvs_common.jvs_cert_rotator_service_account_member
@@ -48,6 +62,11 @@ output "jvs_cert_rotator_service_account_member" {
 output "jvs_public_key_service_account_email" {
   description = "JVS public key service account email."
   value       = module.jvs_common.jvs_public_key_service_account_email
+}
+
+output "jvs_public_key_service_account_name" {
+  description = "JVS public key service account name."
+  value       = module.jvs_common.jvs_public_key_service_account_name
 }
 
 output "jvs_public_key_service_account_member" {

--- a/terraform/ci/outputs.tf
+++ b/terraform/ci/outputs.tf
@@ -20,9 +20,9 @@ output "jvs_api_service_account_email" {
   value       = module.jvs_common.jvs_api_service_account_email
 }
 
-output "jvs_api_service_account_name" {
-  description = "JVS API service account name."
-  value       = module.jvs_common.jvs_api_service_account_name
+output "jvs_api_service_account_member" {
+  description = "JVS API service account member."
+  value       = module.jvs_common.jvs_api_service_account_member
 }
 
 output "jvs_ui_service_account_email" {
@@ -30,9 +30,9 @@ output "jvs_ui_service_account_email" {
   value       = module.jvs_common.jvs_ui_service_account_email
 }
 
-output "jvs_ui_service_account_name" {
-  description = "JVS UI service account name."
-  value       = module.jvs_common.jvs_ui_service_account_name
+output "jvs_ui_service_account_member" {
+  description = "JVS UI service account member."
+  value       = module.jvs_common.jvs_ui_service_account_member
 }
 
 output "jvs_cert_rotator_service_account_email" {
@@ -40,9 +40,9 @@ output "jvs_cert_rotator_service_account_email" {
   value       = module.jvs_common.jvs_cert_rotator_service_account_email
 }
 
-output "jvs_cert_rotator_service_account_name" {
-  description = "JVS cert rotator service account name."
-  value       = module.jvs_common.jvs_cert_rotator_service_account_name
+output "jvs_cert_rotator_service_account_member" {
+  description = "JVS cert rotator service account member."
+  value       = module.jvs_common.jvs_cert_rotator_service_account_member
 }
 
 output "jvs_public_key_service_account_email" {
@@ -50,9 +50,9 @@ output "jvs_public_key_service_account_email" {
   value       = module.jvs_common.jvs_public_key_service_account_email
 }
 
-output "jvs_public_key_service_account_name" {
-  description = "JVS public key service account name."
-  value       = module.jvs_common.jvs_public_key_service_account_name
+output "jvs_public_key_service_account_member" {
+  description = "JVS public key service account member."
+  value       = module.jvs_common.jvs_public_key_service_account_member
 }
 
 output "kms_keyring_id" {

--- a/terraform/modules/common/outputs.tf
+++ b/terraform/modules/common/outputs.tf
@@ -17,6 +17,11 @@ output "jvs_api_service_account_email" {
   value       = google_service_account.api_acc.email
 }
 
+output "jvs_api_service_account_name" {
+  description = "JVS API service account name."
+  value       = google_service_account.api_acc.name
+}
+
 output "jvs_api_service_account_member" {
   description = "JVS API service account member."
   value       = google_service_account.api_acc.member
@@ -25,6 +30,11 @@ output "jvs_api_service_account_member" {
 output "jvs_ui_service_account_email" {
   description = "JVS UI service account email."
   value       = google_service_account.ui_acc.email
+}
+
+output "jvs_ui_service_account_name" {
+  description = "JVS UI service account name."
+  value       = google_service_account.ui_acc.name
 }
 
 output "jvs_ui_service_account_member" {
@@ -37,6 +47,11 @@ output "jvs_cert_rotator_service_account_email" {
   value       = google_service_account.rotator_acc.email
 }
 
+output "jvs_cert_rotator_service_account_name" {
+  description = "JVS cert rotator service account name."
+  value       = google_service_account.rotator_acc.name
+}
+
 output "jvs_cert_rotator_service_account_member" {
   description = "JVS cert rotator service account member."
   value       = google_service_account.rotator_acc.member
@@ -45,6 +60,11 @@ output "jvs_cert_rotator_service_account_member" {
 output "jvs_public_key_service_account_email" {
   description = "JVS public key service account email."
   value       = google_service_account.public_key_acc.email
+}
+
+output "jvs_public_key_service_account_name" {
+  description = "JVS public key service account name."
+  value       = google_service_account.public_key_acc.name
 }
 
 output "jvs_public_key_service_account_member" {

--- a/terraform/modules/common/outputs.tf
+++ b/terraform/modules/common/outputs.tf
@@ -17,9 +17,9 @@ output "jvs_api_service_account_email" {
   value       = google_service_account.api_acc.email
 }
 
-output "jvs_api_service_account_name" {
-  description = "JVS API service account name."
-  value       = google_service_account.api_acc.name
+output "jvs_api_service_account_member" {
+  description = "JVS API service account member."
+  value       = google_service_account.api_acc.member
 }
 
 output "jvs_ui_service_account_email" {
@@ -27,9 +27,9 @@ output "jvs_ui_service_account_email" {
   value       = google_service_account.ui_acc.email
 }
 
-output "jvs_ui_service_account_name" {
-  description = "JVS UI service account name."
-  value       = google_service_account.ui_acc.name
+output "jvs_ui_service_account_member" {
+  description = "JVS UI service account member."
+  value       = google_service_account.ui_acc.member
 }
 
 output "jvs_cert_rotator_service_account_email" {
@@ -37,9 +37,9 @@ output "jvs_cert_rotator_service_account_email" {
   value       = google_service_account.rotator_acc.email
 }
 
-output "jvs_cert_rotator_service_account_name" {
-  description = "JVS cert rotator service account name."
-  value       = google_service_account.rotator_acc.name
+output "jvs_cert_rotator_service_account_member" {
+  description = "JVS cert rotator service account member."
+  value       = google_service_account.rotator_acc.member
 }
 
 output "jvs_public_key_service_account_email" {
@@ -47,9 +47,9 @@ output "jvs_public_key_service_account_email" {
   value       = google_service_account.public_key_acc.email
 }
 
-output "jvs_public_key_service_account_name" {
-  description = "JVS public key service account name."
-  value       = google_service_account.public_key_acc.name
+output "jvs_public_key_service_account_member" {
+  description = "JVS public key service account member."
+  value       = google_service_account.public_key_acc.member
 }
 
 output "kms_keyring_id" {


### PR DESCRIPTION
As we are using member in `infra`, I think we should output `member` instead of `name`.

ref: https://github.com/abcxyz/infra/pull/456/files#diff-a7543b686f684bfbe6aa1d142ccd5ed102b5bc8688472e42613ef2c6cec9d75cR40