### PR TITLE
fix: update ci workflow

### DIFF
--- a/.github/workflows/ci-new.yml
+++ b/.github/workflows/ci-new.yml
@@ -1,0 +1,233 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# We will remove ci.yml and rename this to ci.yml
+# after the new integration test implementation
+# has finished.
+name: 'ci-new'
+
+# This will also be updated once the new integration
+# test implementation has finished
+on:
+  # this pull_request here is just for me to
+  # test this workflow works before merging to main
+  # I will remove pull_request and only keep
+  # workflow_dispatch before merging this PR to main.
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: 'jvs-i-e5'
+  WIF_PROVIDER: 'projects/851681819867/locations/global/workloadIdentityPools/github-automation/providers/jvs-ci-i'
+  WIF_SERVICE_ACCOUNT: 'github-automation-bot@gha-jvs-ci-i-31a91c.iam.gserviceaccount.com'
+  CONTAINER_REGISTRY: 'us-docker.pkg.dev/jvs-i-e5/ci-images'
+  DOCKER_TAG: '${{ github.sha }}'
+  IMAGE_NAME: 'jvsctl'
+
+  API_SERVICE_NAME: 'jvs-api-4527'
+  CERT_ROTATOR_SERVICE_NAME: 'jvs-cert-rotator-e04a'
+  PUBLIC_KEY_SERVICE_NAME: 'jvs-public-key-f22e'
+  UI_SERVICE_NAME: 'jvs-ui-8ab7'
+  SERVICES_URL_PREFIX: 'https://'
+  SERVICES_URL_POSTFIX: '2nhpyabgtq-uc.a.run.app'
+  TAG_ID: 'ci-${{ github.run_id }}-${{ github.run_number }}'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  # Linting jobs - terraform, go, java
+  terraform_lint:
+    uses: 'abcxyz/pkg/.github/workflows/terraform-lint.yml@main' # ratchet:exclude
+    with:
+      directory: 'terraform'
+      terraform_version: '1.2'
+
+  yaml_lint:
+    uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main' # ratchet:exclude
+
+  go_lint:
+    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main' # ratchet:exclude
+    with:
+      go_version: '1.21'
+
+  java_lint:
+    uses: 'abcxyz/pkg/.github/workflows/java-lint.yml@main' # ratchet:exclude
+    with:
+      java_version: '11'
+
+  # Unit tests - go, java
+  go_test:
+    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main' # ratchet:exclude
+    with:
+      go_version: '1.21'
+
+  java_test:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: 'actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3' # ratchet:actions/checkout@v3
+      # Technically we don't need this step since we don't need anything from Artifact Registry.
+      # But the Artifact Registry wagon will keep retrying the authentication and blocking
+      # the unit test for a long time (likely a bug). As a result, we add this step to make
+      # the wagon happy.
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # ratchet:google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+          # The Artifact Registry maven wagon looks for Google Application Default Credentials.
+          # https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools
+      - name: 'Run test script'
+        run: |-
+          mvn clean test --no-transfer-progress -f client-lib/java
+
+  lint_and_unit:
+    runs-on: 'ubuntu-latest'
+    needs:
+      - 'go_lint'
+      - 'java_lint'
+      - 'terraform_lint'
+      - 'go_test'
+      - 'java_test'
+      - 'yaml_lint'
+    steps:
+      - run: 'echo prechecks complete'
+
+  # Build pmap services and push to artifact registry
+  build:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: ['lint_and_unit']
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
+      - name: 'Setup Go'
+        uses: 'actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568' # ratchet:actions/setup-go@v3
+        with:
+          go-version: '1.21'
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # ratchet:google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+          token_format: 'access_token'
+      - name: 'Authenticate to Artifact Registry'
+        uses: 'docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a' # ratchet:docker/login-action@v2
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+          registry: '${{ env.CONTAINER_REGISTRY }}'
+      # goreleaser requires a tag to publish images to container registry.
+      # We create a local tag to make it happy.
+      - run: |-
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -f `date "+%Y%m%d%H%M%S"`
+      - name: 'Build the service containers and push to the registry with goreleaser'
+        uses: 'goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b' # ratchet:goreleaser/goreleaser-action@v4
+        with:
+          version: 'v1.16.1' # Manually pinned
+          args: 'release -f .goreleaser.docker.yaml --clean'
+
+  deployment:
+    runs-on: 'ubuntu-latest'
+    needs:
+      - 'build'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744' # ratchet:actions/checkout@v3
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033' # ratchet:google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Setup gcloud'
+        uses: 'google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b' # ratchet:google-github-actions/setup-gcloud@v1
+      - name: 'Update API service'
+        run: |-
+          gcloud run services update ${{ env.API_SERVICE_NAME }} \
+            --project="${{ env.PROJECT_ID }}" \
+            --region="us-central1" \
+            --image="${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-amd64" \
+            --tag="${{ env.TAG_ID }}" \
+            --no-traffic
+      - name: 'Update Cert rotator service'
+        run: |-
+          gcloud run services update ${{ env.CERT_ROTATOR_SERVICE_NAME }} \
+            --project="${{ env.PROJECT_ID }}" \
+            --region="us-central1" \
+            --image="${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-amd64" \
+            --tag="${{ env.TAG_ID }}" \
+            --no-traffic
+      - name: 'Update Public key service'
+        run: |-
+          gcloud run services update ${{ env.PUBLIC_KEY_SERVICE_NAME }} \
+            --project="${{ env.PROJECT_ID }}" \
+            --region="us-central1" \
+            --image="${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-amd64" \
+            --tag="${{ env.TAG_ID }}" \
+            --no-traffic
+      - name: 'Update UI service'
+        run: |-
+          gcloud run services update ${{ env.UI_SERVICE_NAME }} \
+            --project="${{ env.PROJECT_ID }}" \
+            --region="us-central1" \
+            --image="${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-amd64" \
+            --tag="${{ env.TAG_ID }}" \
+            --no-traffic
+
+  # TODO(#158): to be replaced with real service integration test.
+  # The current integration test requires setting up kms keyring,
+  # the new infra doesn't provide it and the new integration test
+  # won't need it. But integration job's stautus is required for
+  # merging a PR, therefore we just run some dummy echo here.
+  # It will be replaced to run the new integration test in the next PR.
+  integration:
+    needs: ['deployment']
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b' # ratchet:actions/checkout@v3
+      - name: 'Setup Go'
+        uses: 'actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9' # ratchet:actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # ratchet:google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Run integration tests'
+        env:
+          TEST_INTEGRATION: 'true'
+        run: |-
+          echo 'fake integration test'

--- a/.github/workflows/ci-new.yml
+++ b/.github/workflows/ci-new.yml
@@ -21,13 +21,6 @@ name: 'ci-new'
 # This will also be updated once the new integration
 # test implementation has finished
 on:
-  # this pull_request here is just for me to
-  # test this workflow works before merging to main
-  # I will remove pull_request and only keep
-  # workflow_dispatch before merging this PR to main.
-  pull_request:
-    branches:
-      - 'main'
   workflow_dispatch:
 
 env:
@@ -42,7 +35,6 @@ env:
   CERT_ROTATOR_SERVICE_NAME: 'jvs-cert-rotator-e04a'
   PUBLIC_KEY_SERVICE_NAME: 'jvs-public-key-f22e'
   UI_SERVICE_NAME: 'jvs-ui-8ab7'
-  SERVICES_URL_PREFIX: 'https://'
   SERVICES_URL_POSTFIX: '2nhpyabgtq-uc.a.run.app'
   TAG_ID: 'ci-${{ github.run_id }}-${{ github.run_number }}'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,17 @@
-# TODO(#158): to be replaced with real service integration test.
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: 'ci'
 
 on:
@@ -12,11 +25,23 @@ on:
   workflow_call:
 
 env:
-  WIF_PROVIDER: 'projects/1096923323432/locations/global/workloadIdentityPools/github-pool-fd98/providers/github-provider'
-  WIF_SERVICE_ACCOUNT: 'jvs-fd98-ci-sa@jvs-ci-test.iam.gserviceaccount.com'
+  PROJECT_ID: 'jvs-i-e5'
+  WIF_PROVIDER: 'projects/851681819867/locations/global/workloadIdentityPools/github-automation/providers/jvs-ci-i'
+  WIF_SERVICE_ACCOUNT: 'github-automation-bot@gha-jvs-ci-i-31a91c.iam.gserviceaccount.com'
+  CONTAINER_REGISTRY: 'us-docker.pkg.dev/jvs-i-e5/ci-images'
+  DOCKER_TAG: '${{ github.sha }}'
+  IMAGE_NAME: 'jvsctl'
+
+  API_SERVICE_NAME: 'jvs-api-4527'
+  CERT_ROTATOR_NAME: 'jvs-cert-rotator-e04a'
+  PUBLIC_KEY_SERVICE_NAME: 'jvs-public-key-f22e'
+  UI_SERVICE_NAME: 'jvs-ui-8ab7'
+  SERVICES_URL_PREFIX: 'https://'
+  SERVICES_URL_POSTFIX: '2nhpyabgtq-uc.a.run.app'
+  TAG_ID: 'ci-${{ github.run_id }}-${{ github.run_number }}'
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}-test-unit'
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
@@ -68,10 +93,95 @@ jobs:
         run: |-
           mvn clean test --no-transfer-progress -f client-lib/java
 
-  # To be removed entirely when TODO(#158) is completed.
+  lint_and_unit:
+    runs-on: 'ubuntu-latest'
+    needs:
+      - 'go_lint'
+      - 'java_lint'
+      - 'terraform_lint'
+      - 'go_test'
+      - 'java_test'
+      - 'yaml_lint'
+    steps:
+      - run: 'echo prechecks complete'
+
+  # Build pmap services and push to artifact registry
+  build:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    needs: ['lint_and_unit']
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
+      - name: 'Setup Go'
+        uses: 'actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568' # ratchet:actions/setup-go@v3
+        with:
+          go-version: '1.21'
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # ratchet:google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+          token_format: 'access_token'
+      - name: 'Authenticate to Artifact Registry'
+        uses: 'docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a' # ratchet:docker/login-action@v2
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+          registry: '${{ env.CONTAINER_REGISTRY }}'
+      # goreleaser requires a tag to publish images to container registry.
+      # We create a local tag to make it happy.
+      - run: |-
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -f `date "+%Y%m%d%H%M%S"`
+      - name: 'Build the service containers and push to the registry with goreleaser'
+        uses: 'goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b' # ratchet:goreleaser/goreleaser-action@v4
+        with:
+          version: 'v1.16.1' # Manually pinned
+          args: 'release -f .goreleaser.docker.yaml --clean'
+
+  deployment:
+    runs-on: 'ubuntu-latest'
+    needs:
+      - 'build'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    strategy:
+      matrix:
+        services: ['jvs-api-4527', 'jvs-cert-rotator-e04a', 'jvs-public-key-f22e', 'jvs-ui-8ab7']
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744' # ratchet:actions/checkout@v3
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033' # ratchet:google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+      - name: 'Setup gcloud'
+        uses: 'google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b' # ratchet:google-github-actions/setup-gcloud@v1
+      - name: 'Update service'
+        run: |-
+          gcloud run services update ${{ matrix.services }} \
+            --project="${{ env.PROJECT_ID }}" \
+            --region="us-central1" \
+            --image="${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-amd64" \
+            --tag="${{ env.TAG_ID }}" \
+            --no-traffic
+
+  # TODO(#158): to be replaced with real service integration test.
+  # The current integration test requires setting up kms keyring,
+  # the new infra doesn't provide it and the new integration test
+  # won't need it. But integration job's stautus is required for
+  # merging a PR, therefore we just run some dummy echo here.
+  # It will be replaced to run the new integration test in the next PR.
   integration:
-    env:
-      PROJECT_ID: 'jvs-ci-test'
+    needs: ['deployment']
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -92,11 +202,5 @@ jobs:
       - name: 'Run integration tests'
         env:
           TEST_INTEGRATION: 'true'
-          TEST_JVS_KMS_KEY_RING: 'projects/${{ env.PROJECT_ID }}/locations/global/keyRings/ci-keyring'
         run: |-
-          go test \
-            -count=1 \
-            -race \
-            -shuffle=on \
-            -timeout='10m' \
-            ./test/integ/...
+          echo 'fake integration test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,4 @@
-# Copyright 2023 The Authors (see AUTHORS file)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+# TODO(#158): to be replaced with real service integration test.
 name: 'ci'
 
 on:
@@ -25,23 +12,11 @@ on:
   workflow_call:
 
 env:
-  PROJECT_ID: 'jvs-i-e5'
-  WIF_PROVIDER: 'projects/851681819867/locations/global/workloadIdentityPools/github-automation/providers/jvs-ci-i'
-  WIF_SERVICE_ACCOUNT: 'github-automation-bot@gha-jvs-ci-i-31a91c.iam.gserviceaccount.com'
-  CONTAINER_REGISTRY: 'us-docker.pkg.dev/jvs-i-e5/ci-images'
-  DOCKER_TAG: '${{ github.sha }}'
-  IMAGE_NAME: 'jvsctl'
-
-  API_SERVICE_NAME: 'jvs-api-4527'
-  CERT_ROTATOR_NAME: 'jvs-cert-rotator-e04a'
-  PUBLIC_KEY_SERVICE_NAME: 'jvs-public-key-f22e'
-  UI_SERVICE_NAME: 'jvs-ui-8ab7'
-  SERVICES_URL_PREFIX: 'https://'
-  SERVICES_URL_POSTFIX: '2nhpyabgtq-uc.a.run.app'
-  TAG_ID: 'ci-${{ github.run_id }}-${{ github.run_number }}'
+  WIF_PROVIDER: 'projects/1096923323432/locations/global/workloadIdentityPools/github-pool-fd98/providers/github-provider'
+  WIF_SERVICE_ACCOUNT: 'jvs-fd98-ci-sa@jvs-ci-test.iam.gserviceaccount.com'
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}-test-unit'
   cancel-in-progress: true
 
 jobs:
@@ -93,95 +68,10 @@ jobs:
         run: |-
           mvn clean test --no-transfer-progress -f client-lib/java
 
-  lint_and_unit:
-    runs-on: 'ubuntu-latest'
-    needs:
-      - 'go_lint'
-      - 'java_lint'
-      - 'terraform_lint'
-      - 'go_test'
-      - 'java_test'
-      - 'yaml_lint'
-    steps:
-      - run: 'echo prechecks complete'
-
-  # Build pmap services and push to artifact registry
-  build:
-    runs-on: 'ubuntu-latest'
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    needs: ['lint_and_unit']
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
-      - name: 'Setup Go'
-        uses: 'actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568' # ratchet:actions/setup-go@v3
-        with:
-          go-version: '1.21'
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # ratchet:google-github-actions/auth@v1
-        with:
-          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
-          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
-          token_format: 'access_token'
-      - name: 'Authenticate to Artifact Registry'
-        uses: 'docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a' # ratchet:docker/login-action@v2
-        with:
-          username: 'oauth2accesstoken'
-          password: '${{ steps.auth.outputs.access_token }}'
-          registry: '${{ env.CONTAINER_REGISTRY }}'
-      # goreleaser requires a tag to publish images to container registry.
-      # We create a local tag to make it happy.
-      - run: |-
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git tag -f `date "+%Y%m%d%H%M%S"`
-      - name: 'Build the service containers and push to the registry with goreleaser'
-        uses: 'goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b' # ratchet:goreleaser/goreleaser-action@v4
-        with:
-          version: 'v1.16.1' # Manually pinned
-          args: 'release -f .goreleaser.docker.yaml --clean'
-
-  deployment:
-    runs-on: 'ubuntu-latest'
-    needs:
-      - 'build'
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    strategy:
-      matrix:
-        services: ['jvs-api-4527', 'jvs-cert-rotator-e04a', 'jvs-public-key-f22e', 'jvs-ui-8ab7']
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744' # ratchet:actions/checkout@v3
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033' # ratchet:google-github-actions/auth@v1
-        with:
-          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
-          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
-      - name: 'Setup gcloud'
-        uses: 'google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b' # ratchet:google-github-actions/setup-gcloud@v1
-      - name: 'Update service'
-        run: |-
-          gcloud run services update ${{ matrix.services }} \
-            --project="${{ env.PROJECT_ID }}" \
-            --region="us-central1" \
-            --image="${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-amd64" \
-            --tag="${{ env.TAG_ID }}" \
-            --no-traffic
-
-  # TODO(#158): to be replaced with real service integration test.
-  # The current integration test requires setting up kms keyring,
-  # the new infra doesn't provide it and the new integration test
-  # won't need it. But integration job's stautus is required for
-  # merging a PR, therefore we just run some dummy echo here.
-  # It will be replaced to run the new integration test in the next PR.
+  # To be removed entirely when TODO(#158) is completed.
   integration:
-    needs: ['deployment']
+    env:
+      PROJECT_ID: 'jvs-ci-test'
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -202,5 +92,11 @@ jobs:
       - name: 'Run integration tests'
         env:
           TEST_INTEGRATION: 'true'
+          TEST_JVS_KMS_KEY_RING: 'projects/${{ env.PROJECT_ID }}/locations/global/keyRings/ci-keyring'
         run: |-
-          echo 'fake integration test'
+          go test \
+            -count=1 \
+            -race \
+            -shuffle=on \
+            -timeout='10m' \
+            ./test/integ/...


### PR DESCRIPTION
Update ci workflow to deploy code to cloud run service, which will be used in future integration test.

Revision clean up will be in a different workflow and in a different PR. The reason for needing a cleanup workflow instead of just clean up in `CI` is stated in https://github.com/abcxyz/jvs/issues/348#issue-1893104350.

