### PR TITLE
feat: add ci AR repo clean up policy

### DIFF
--- a/.github/workflows/update-ci-ar-cleanup-policy.yml
+++ b/.github/workflows/update-ci-ar-cleanup-policy.yml
@@ -25,9 +25,6 @@ name: 'update-ci-ar-cleanup-policy'
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - 'main'
 
 env:
   WIF_PROVIDER: 'projects/851681819867/locations/global/workloadIdentityPools/github-automation/providers/jvs-ci-i'
@@ -82,4 +79,4 @@ jobs:
             --project=${{ env.CI_PROJECT_ID }}\
             --location=us\
             --policy=${{ env.AR_CONFIG_FILE }}\
-            --dry-run
+            --no-dry-run

--- a/.github/workflows/update-ci-ar-cleanup-policy.yml
+++ b/.github/workflows/update-ci-ar-cleanup-policy.yml
@@ -1,0 +1,85 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow will be manully triggered to update CI project's
+# artifact registry clean up policy. This should be set up by terraform,
+# however it's not supported yet. We will remove this and use terraform
+# to set up this once it's supported.
+# To enable clean up policy, the ci service need to be granted the role
+# of [roles/artifactregistry.admin]
+
+# https://cloud.google.com/artifact-registry/docs/repositories/cleanup-policy
+
+name: 'update-ci-ar-cleanup-policy'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'main'
+
+env:
+  WIF_PROVIDER: 'projects/851681819867/locations/global/workloadIdentityPools/github-automation/providers/jvs-ci-i'
+  WIF_SERVICE_ACCOUNT: 'github-automation-bot@gha-jvs-ci-i-31a91c.iam.gserviceaccount.com'
+  CI_PROJECT_ID: 'jvs-i-e5'
+  DOCKER_REGISTRY: 'us-docker.pkg.dev'
+  DOCKER_REPO: 'ci-images'
+
+jobs:
+  write_policy_config:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' # ratchet:actions/checkout@v3
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # ratchet:google-github-actions/auth@v1
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+          token_format: 'access_token'
+      - name: 'Authenticate to Artifact Registry'
+        uses: 'docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a' # ratchet:docker/login-action@v2
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+          registry: '${{ env.DOCKER_REGISTRY }}'
+      - name: 'Write cleanup config file'
+        run: |-
+          CONFIG_FILE='${{ runner.temp }}/ci-clean-policy.json'
+
+          touch ${CONFIG_FILE}
+          cat << EOT >> ${CONFIG_FILE}
+          [
+            {
+                "name": "delete-old-ci-images",
+                "action": {"type": "Delete"},
+                "condition": {
+                    "olderThan": "3d"
+                }
+            }
+          ]
+          EOT
+          cat ${CONFIG_FILE}
+          echo "AR_CONFIG_FILE=${CONFIG_FILE}" >> $GITHUB_ENV;
+      - name: 'Apply cleanup config'
+        run: |-
+          gcloud artifacts repositories set-cleanup-policies ${{ env.DOCKER_REPO }}\
+            --project=${{ env.CI_PROJECT_ID }}\
+            --location=us\
+            --policy=${{ env.AR_CONFIG_FILE }}\
+            --dry-run


### PR DESCRIPTION
Changed to `no-dry-run`, you can view the dry run result here:
https://github.com/abcxyz/jvs/actions/runs/6178021111

I will manually trigger this workflow after this PR is merged.