### PR TITLE
fix: change /healthz to /health to fix cloud run known issue

### DIFF
--- a/pkg/cli/public_key_server.go
+++ b/pkg/cli/public_key_server.go
@@ -119,7 +119,10 @@ func (c *PublicKeyServerCommand) RunUnstarted(ctx context.Context, args []string
 	keyServer := jvscrypto.NewKeyServer(ctx, kmsClient, c.cfg, h)
 
 	mux := http.NewServeMux()
-	// This is the healthz checkpoint.
+
+	// Use /health instead of /healthz to avoid cloud run reserved path
+	//
+	// See: https://cloud.google.com/run/docs/issues#ah
 	mux.Handle("/health", healthcheck.HandleHTTPHealthCheck())
 	mux.Handle("/.well-known/jwks", keyServer)
 

--- a/pkg/cli/public_key_server.go
+++ b/pkg/cli/public_key_server.go
@@ -119,7 +119,11 @@ func (c *PublicKeyServerCommand) RunUnstarted(ctx context.Context, args []string
 	keyServer := jvscrypto.NewKeyServer(ctx, kmsClient, c.cfg, h)
 
 	mux := http.NewServeMux()
-	mux.Handle("/healthz", healthcheck.HandleHTTPHealthCheck())
+	// This is the healthz checkpoint, but in cloud run url ending with z
+	// could be reservered. This is to fix that.
+	//
+	// See: https://cloud.google.com/run/docs/issues#ah
+	mux.Handle("/healthz-check", healthcheck.HandleHTTPHealthCheck())
 	mux.Handle("/.well-known/jwks", keyServer)
 
 	root := logging.HTTPInterceptor(logger, c.cfg.ProjectID)(mux)

--- a/pkg/cli/public_key_server.go
+++ b/pkg/cli/public_key_server.go
@@ -119,11 +119,8 @@ func (c *PublicKeyServerCommand) RunUnstarted(ctx context.Context, args []string
 	keyServer := jvscrypto.NewKeyServer(ctx, kmsClient, c.cfg, h)
 
 	mux := http.NewServeMux()
-	// This is the healthz checkpoint, but in cloud run url ending with z
-	// could be reserved. This is to fix that.
-	//
-	// See: https://cloud.google.com/run/docs/issues#ah
-	mux.Handle("/healthz-check", healthcheck.HandleHTTPHealthCheck())
+	// This is the healthz checkpoint.
+	mux.Handle("/health", healthcheck.HandleHTTPHealthCheck())
 	mux.Handle("/.well-known/jwks", keyServer)
 
 	root := logging.HTTPInterceptor(logger, c.cfg.ProjectID)(mux)

--- a/pkg/cli/public_key_server.go
+++ b/pkg/cli/public_key_server.go
@@ -120,7 +120,7 @@ func (c *PublicKeyServerCommand) RunUnstarted(ctx context.Context, args []string
 
 	mux := http.NewServeMux()
 	// This is the healthz checkpoint, but in cloud run url ending with z
-	// could be reservered. This is to fix that.
+	// could be reserved. This is to fix that.
 	//
 	// See: https://cloud.google.com/run/docs/issues#ah
 	mux.Handle("/healthz-check", healthcheck.HandleHTTPHealthCheck())

--- a/pkg/cli/public_key_server_test.go
+++ b/pkg/cli/public_key_server_test.go
@@ -107,7 +107,7 @@ func TestPublicKeyServerCommand(t *testing.T) {
 				Timeout: 5 * time.Second,
 			}
 
-			uri := "http://" + srv.Addr() + "/healthz"
+			uri := "http://" + srv.Addr() + "/healthz-check"
 			req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cli/public_key_server_test.go
+++ b/pkg/cli/public_key_server_test.go
@@ -107,7 +107,7 @@ func TestPublicKeyServerCommand(t *testing.T) {
 				Timeout: 5 * time.Second,
 			}
 
-			uri := "http://" + srv.Addr() + "/healthz-check"
+			uri := "http://" + srv.Addr() + "/health"
 			req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cli/rotation_server.go
+++ b/pkg/cli/rotation_server.go
@@ -122,7 +122,7 @@ func (c *RotationServerCommand) RunUnstarted(ctx context.Context, args []string)
 
 	mux := http.NewServeMux()
 	// This is the healthz checkpoint, but in cloud run url ending with z
-	// could be reservered. This is to fix that.
+	// could be reserved. This is to fix that.
 	//
 	// See: https://cloud.google.com/run/docs/issues#ah
 	mux.Handle("/healthz-check", healthcheck.HandleHTTPHealthCheck())

--- a/pkg/cli/rotation_server.go
+++ b/pkg/cli/rotation_server.go
@@ -121,7 +121,11 @@ func (c *RotationServerCommand) RunUnstarted(ctx context.Context, args []string)
 	rotationHandler := jvscrypto.NewRotationHandler(ctx, kmsClient, c.cfg)
 
 	mux := http.NewServeMux()
-	mux.Handle("/healthz", healthcheck.HandleHTTPHealthCheck())
+	// This is the healthz checkpoint, but in cloud run url ending with z
+	// could be reservered. This is to fix that.
+	//
+	// See: https://cloud.google.com/run/docs/issues#ah
+	mux.Handle("/healthz-check", healthcheck.HandleHTTPHealthCheck())
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 

--- a/pkg/cli/rotation_server.go
+++ b/pkg/cli/rotation_server.go
@@ -121,7 +121,10 @@ func (c *RotationServerCommand) RunUnstarted(ctx context.Context, args []string)
 	rotationHandler := jvscrypto.NewRotationHandler(ctx, kmsClient, c.cfg)
 
 	mux := http.NewServeMux()
-	// This is the health checkpoint.
+
+	// Use /health instead of /healthz to avoid cloud run reserved path
+	//
+	// See: https://cloud.google.com/run/docs/issues#ah
 	mux.Handle("/health", healthcheck.HandleHTTPHealthCheck())
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/pkg/cli/rotation_server.go
+++ b/pkg/cli/rotation_server.go
@@ -121,11 +121,8 @@ func (c *RotationServerCommand) RunUnstarted(ctx context.Context, args []string)
 	rotationHandler := jvscrypto.NewRotationHandler(ctx, kmsClient, c.cfg)
 
 	mux := http.NewServeMux()
-	// This is the healthz checkpoint, but in cloud run url ending with z
-	// could be reserved. This is to fix that.
-	//
-	// See: https://cloud.google.com/run/docs/issues#ah
-	mux.Handle("/healthz-check", healthcheck.HandleHTTPHealthCheck())
+	// This is the health checkpoint.
+	mux.Handle("/health", healthcheck.HandleHTTPHealthCheck())
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 

--- a/pkg/cli/rotation_server_test.go
+++ b/pkg/cli/rotation_server_test.go
@@ -108,7 +108,7 @@ func TestRotationServerCommand(t *testing.T) {
 				Timeout: 5 * time.Second,
 			}
 
-			uri := "http://" + srv.Addr() + "/healthz"
+			uri := "http://" + srv.Addr() + "/healthz-check"
 			req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cli/rotation_server_test.go
+++ b/pkg/cli/rotation_server_test.go
@@ -108,7 +108,7 @@ func TestRotationServerCommand(t *testing.T) {
 				Timeout: 5 * time.Second,
 			}
 
-			uri := "http://" + srv.Addr() + "/healthz-check"
+			uri := "http://" + srv.Addr() + "/health"
 			req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cli/ui_server_test.go
+++ b/pkg/cli/ui_server_test.go
@@ -109,7 +109,7 @@ func TestUIServerCommand(t *testing.T) {
 				Timeout: 5 * time.Second,
 			}
 
-			uri := "http://" + srv.Addr() + "/healthz"
+			uri := "http://" + srv.Addr() + "/healthz-check"
 			req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/cli/ui_server_test.go
+++ b/pkg/cli/ui_server_test.go
@@ -109,7 +109,7 @@ func TestUIServerCommand(t *testing.T) {
 				Timeout: 5 * time.Second,
 			}
 
-			uri := "http://" + srv.Addr() + "/healthz-check"
+			uri := "http://" + srv.Addr() + "/health"
 			req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -68,7 +68,11 @@ func (s *Server) Routes(ctx context.Context) http.Handler {
 	fileServer := http.FileServer(http.FS(staticFS))
 
 	mux := http.NewServeMux()
-	mux.Handle("/healthz", s.c.HandleHealth())
+	// This is the healthz checkpoint, but in cloud run url ending with z
+	// could be reservered. This is to fix that.
+	//
+	// See: https://cloud.google.com/run/docs/issues#ah
+	mux.Handle("/healthz-check", s.c.HandleHealth())
 	mux.Handle("/static/", http.StripPrefix("/static/", fileServer))
 	mux.Handle("/popup", s.c.HandlePopup())
 

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -68,11 +68,8 @@ func (s *Server) Routes(ctx context.Context) http.Handler {
 	fileServer := http.FileServer(http.FS(staticFS))
 
 	mux := http.NewServeMux()
-	// This is the healthz checkpoint, but in cloud run url ending with z
-	// could be reserved. This is to fix that.
-	//
-	// See: https://cloud.google.com/run/docs/issues#ah
-	mux.Handle("/healthz-check", s.c.HandleHealth())
+	// This is the health checkpoint.
+	mux.Handle("/health", s.c.HandleHealth())
 	mux.Handle("/static/", http.StripPrefix("/static/", fileServer))
 	mux.Handle("/popup", s.c.HandlePopup())
 

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -69,7 +69,7 @@ func (s *Server) Routes(ctx context.Context) http.Handler {
 
 	mux := http.NewServeMux()
 	// This is the healthz checkpoint, but in cloud run url ending with z
-	// could be reservered. This is to fix that.
+	// could be reserved. This is to fix that.
 	//
 	// See: https://cloud.google.com/run/docs/issues#ah
 	mux.Handle("/healthz-check", s.c.HandleHealth())

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -68,7 +68,10 @@ func (s *Server) Routes(ctx context.Context) http.Handler {
 	fileServer := http.FileServer(http.FS(staticFS))
 
 	mux := http.NewServeMux()
-	// This is the health checkpoint.
+
+	// Use /health instead of /healthz to avoid cloud run reserved path
+	//
+	// See: https://cloud.google.com/run/docs/issues#ah
 	mux.Handle("/health", s.c.HandleHealth())
 	mux.Handle("/static/", http.StripPrefix("/static/", fileServer))
 	mux.Handle("/popup", s.c.HandlePopup())


### PR DESCRIPTION
Url ending with `z` could cause trouble. 
See: https://cloud.google.com/run/docs/issues#ah

We can also use `health` as the endpoint for cloud run  HTTP liveness probe in the future if we want to.