### PR TITLE
fix: set rotation time to 0

### DIFF
--- a/terraform/ci/main.tf
+++ b/terraform/ci/main.tf
@@ -54,5 +54,7 @@ module "jvs_services" {
 
   kms_keyring_id = module.jvs_common.kms_keyring_id
   kms_key_name   = "signing-${random_id.default.hex}"
+
+  kms_key_rotation_minutes = 0
 }
 


### PR DESCRIPTION
In CI, we don't need key to be rotated.