### PR TITLE
chore: update terraform version for tf lint

### DIFF
--- a/.github/workflows/ci-new.yml
+++ b/.github/workflows/ci-new.yml
@@ -49,7 +49,7 @@ jobs:
     uses: 'abcxyz/pkg/.github/workflows/terraform-lint.yml@main' # ratchet:exclude
     with:
       directory: 'terraform'
-      terraform_version: '1.2'
+      terraform_version: '1.3'
 
   yaml_lint:
     uses: 'abcxyz/pkg/.github/workflows/yaml-lint.yml@main' # ratchet:exclude


### PR DESCRIPTION
to fix lint for optional version with type.
See: https://github.com/abcxyz/jvs/actions/runs/6462273040/job/17543580535