### PR TITLE
fix: add plugin_secret_envvars so CR service can get secret directly

### DIFF
--- a/terraform/e2e/main.tf
+++ b/terraform/e2e/main.tf
@@ -71,9 +71,10 @@ module "jvs_services" {
 
   jvs_container_image = var.jvs_container_image
 
-  kms_keyring_id = module.jvs_common.kms_keyring_id
-  kms_key_name   = "signing-${random_id.default.hex}"
-  plugin_envvars = var.plugin_envvars
+  kms_keyring_id        = module.jvs_common.kms_keyring_id
+  kms_key_name          = "signing-${random_id.default.hex}"
+  plugin_envvars        = var.plugin_envvars
+  plugin_secret_envvars = var.plugin_secret_envvars
 }
 
 module "jvs_monitoring" {

--- a/terraform/e2e/variables.tf
+++ b/terraform/e2e/variables.tf
@@ -85,3 +85,12 @@ variable "alert_enabled" {
   description = "True if alerts are enabled, otherwise false."
   default     = false
 }
+
+variable "plugin_secret_envvars" {
+  description = "Secret environment variables from Secret Manager for the plugin."
+  type = map(object({
+    name    = string
+    version = string
+  }))
+  default = {}
+}

--- a/terraform/modules/jvs-services/jvs-api.tf
+++ b/terraform/modules/jvs-services/jvs-api.tf
@@ -30,4 +30,6 @@ module "api_cloud_run" {
     "PROJECT_ID" : var.project_id
     "JVS_KEY" : google_kms_crypto_key.signing_key.id,
   }, var.api_envvars, var.plugin_envvars)
+
+  secret_envvars = var.plugin_secret_envvars
 }

--- a/terraform/modules/jvs-services/jvs-ui.tf
+++ b/terraform/modules/jvs-services/jvs-ui.tf
@@ -36,4 +36,6 @@ module "ui_cloud_run" {
     "PROJECT_ID" : var.project_id
     "JVS_KEY" : google_kms_crypto_key.signing_key.id
   }, var.ui_envvars, var.plugin_envvars)
+
+  secret_envvars = var.plugin_secret_envvars
 }

--- a/terraform/modules/jvs-services/variables.tf
+++ b/terraform/modules/jvs-services/variables.tf
@@ -115,3 +115,12 @@ variable "plugin_envvars" {
   type        = map(string)
   default     = {}
 }
+
+variable "plugin_secret_envvars" {
+  description = "Secret environment variables from Secret Manager for the plugin."
+  type = map(object({
+    name    = string
+    version = string
+  }))
+  default = {}
+}


### PR DESCRIPTION
Add `plugin_secret_envvars` variables so we can use the [secret_envvars](https://github.com/abcxyz/terraform-modules/blob/main/modules/cloud_run/main.tf#L121C11-L133) from `abcxyz/terraform-module/cloud_run`, and get secret from secret manager directly.