### PR TITLE
chore: use gci for import ordering

### DIFF
--- a/apis/v0/breakglass_test.go
+++ b/apis/v0/breakglass_test.go
@@ -19,11 +19,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestCreateBreakglassToken(t *testing.T) {

--- a/apis/v0/jwt_test.go
+++ b/apis/v0/jwt_test.go
@@ -20,11 +20,12 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestGetRequestor(t *testing.T) {

--- a/client-lib/go/client/jvs_client.go
+++ b/client-lib/go/client/jvs_client.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"time"
 
-	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
 )
 
 // JVSClient allows for getting JWK keys from the JVS and validating JWTs with

--- a/client-lib/go/client/jvs_client_test.go
+++ b/client-lib/go/client/jvs_client_test.go
@@ -26,13 +26,14 @@ import (
 	"testing"
 	"time"
 
-	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestValidateJWT(t *testing.T) {

--- a/client-lib/go/client/jvs_config_test.go
+++ b/client-lib/go/client/jvs_config_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-envconfig"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestLoadJVSConfig(t *testing.T) {

--- a/internal/envtest/envtest.go
+++ b/internal/envtest/envtest.go
@@ -25,6 +25,9 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+
 	"github.com/abcxyz/jvs/assets"
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/justification"
@@ -34,8 +37,6 @@ import (
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/renderer"
 	pkgtestutil "github.com/abcxyz/pkg/testutil"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 )
 
 // ServerConfigResponse is the response from creating a server config.

--- a/pkg/cli/api_server.go
+++ b/pkg/cli/api_server.go
@@ -19,6 +19,11 @@ import (
 	"fmt"
 
 	kms "cloud.google.com/go/kms/apiv1"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/abcxyz/jvs/internal/version"
 	"github.com/abcxyz/jvs/pkg/config"
@@ -29,10 +34,6 @@ import (
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/multicloser"
 	"github.com/abcxyz/pkg/serving"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 )
 
 var _ cli.Command = (*APIServerCommand)(nil)

--- a/pkg/cli/api_server_test.go
+++ b/pkg/cli/api_server_test.go
@@ -18,13 +18,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/abcxyz/pkg/cli"
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/testutil"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/abcxyz/pkg/cli"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestAPIServerCommand(t *testing.T) {

--- a/pkg/cli/public_key_server.go
+++ b/pkg/cli/public_key_server.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 
 	kms "cloud.google.com/go/kms/apiv1"
+	"google.golang.org/api/option"
+
 	"github.com/abcxyz/jvs/internal/version"
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/jvscrypto"
@@ -29,7 +31,6 @@ import (
 	"github.com/abcxyz/pkg/multicloser"
 	"github.com/abcxyz/pkg/renderer"
 	"github.com/abcxyz/pkg/serving"
-	"google.golang.org/api/option"
 )
 
 var _ cli.Command = (*PublicKeyServerCommand)(nil)

--- a/pkg/cli/public_key_server_test.go
+++ b/pkg/cli/public_key_server_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/api/option"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
-	"google.golang.org/api/option"
 )
 
 func TestPublicKeyServerCommand(t *testing.T) {

--- a/pkg/cli/rotation_server.go
+++ b/pkg/cli/rotation_server.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 
 	kms "cloud.google.com/go/kms/apiv1"
+	"google.golang.org/api/option"
+
 	"github.com/abcxyz/jvs/internal/version"
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/jvscrypto"
@@ -29,7 +31,6 @@ import (
 	"github.com/abcxyz/pkg/multicloser"
 	"github.com/abcxyz/pkg/renderer"
 	"github.com/abcxyz/pkg/serving"
-	"google.golang.org/api/option"
 )
 
 var _ cli.Command = (*RotationServerCommand)(nil)

--- a/pkg/cli/rotation_server_test.go
+++ b/pkg/cli/rotation_server_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/api/option"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
-	"google.golang.org/api/option"
 )
 
 func TestRotationServerCommand(t *testing.T) {

--- a/pkg/cli/token_create_test.go
+++ b/pkg/cli/token_create_test.go
@@ -23,15 +23,16 @@ import (
 	"testing"
 	"time"
 
-	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/jvs/pkg/justification"
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"google.golang.org/grpc"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/jvs/pkg/justification"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestTokenCreateCommand(t *testing.T) {

--- a/pkg/cli/token_validate_test.go
+++ b/pkg/cli/token_validate_test.go
@@ -28,15 +28,16 @@ import (
 	"testing"
 	"time"
 
-	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/jvs/pkg/justification"
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/jvs/pkg/justification"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestNewValidateCmd(t *testing.T) {

--- a/pkg/cli/ui_server.go
+++ b/pkg/cli/ui_server.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 
 	kms "cloud.google.com/go/kms/apiv1"
+	"google.golang.org/api/option"
+
 	"github.com/abcxyz/jvs/internal/version"
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/justification"
@@ -29,7 +31,6 @@ import (
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/multicloser"
 	"github.com/abcxyz/pkg/serving"
-	"google.golang.org/api/option"
 )
 
 var _ cli.Command = (*UIServerCommand)(nil)

--- a/pkg/cli/ui_server_test.go
+++ b/pkg/cli/ui_server_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/api/option"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
-	"google.golang.org/api/option"
 )
 
 func TestUIServerCommand(t *testing.T) {

--- a/pkg/config/cert_rotation_config_test.go
+++ b/pkg/config/cert_rotation_config_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestCertRotationConfig_ToFlags(t *testing.T) {

--- a/pkg/config/justification_config_test.go
+++ b/pkg/config/justification_config_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestJustificationConfig_ToFlags(t *testing.T) {

--- a/pkg/config/public_key_config_test.go
+++ b/pkg/config/public_key_config_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestPublicKeyConfig_ToFlags(t *testing.T) {

--- a/pkg/config/ui_config_test.go
+++ b/pkg/config/ui_config_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/pkg/cli"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestUIServiceConfig_ToFlags(t *testing.T) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -24,13 +24,13 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/abcxyz/jvs/internal/project"
 	"github.com/abcxyz/jvs/pkg/justification"
 	"github.com/abcxyz/pkg/renderer"
-
-	"golang.org/x/exp/slices"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 var ttls = map[string]struct{}{

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -23,13 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/abcxyz/jvs/internal/envtest"
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/justification"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/testing/protocmp"
 )
 
 type mockValidator struct {

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -22,8 +22,9 @@ import (
 	"io"
 	"sort"
 
-	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
 )
 
 // Formatter is an interface which all formatters must implement.

--- a/pkg/formatter/text.go
+++ b/pkg/formatter/text.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"time"
 
-	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
 )
 
 // Text outputs the token into three sections:

--- a/pkg/idtoken/idtoken_test.go
+++ b/pkg/idtoken/idtoken_test.go
@@ -22,11 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"golang.org/x/oauth2"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 type fakeDefaultTokenSource struct {

--- a/pkg/justification/processor.go
+++ b/pkg/justification/processor.go
@@ -21,12 +21,6 @@ import (
 	"time"
 
 	kms "cloud.google.com/go/kms/apiv1"
-	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/jvs/pkg/config"
-	"github.com/abcxyz/jvs/pkg/jvscrypto"
-	"github.com/abcxyz/pkg/cache"
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/timeutil"
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jws"
@@ -34,6 +28,13 @@ import (
 	"github.com/sethvargo/go-gcpkms/pkg/gcpkms"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/abcxyz/jvs/pkg/jvscrypto"
+	"github.com/abcxyz/pkg/cache"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/timeutil"
 )
 
 // Processor performs the necessary logic to validate a justification, then

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -29,12 +29,6 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
-	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/jvs/pkg/config"
-	"github.com/abcxyz/jvs/pkg/jvscrypto"
-	"github.com/abcxyz/jvs/pkg/testutil"
-	"github.com/abcxyz/pkg/logging"
-	pkgtestutil "github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -46,6 +40,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/abcxyz/jvs/pkg/jvscrypto"
+	"github.com/abcxyz/jvs/pkg/testutil"
+	"github.com/abcxyz/pkg/logging"
+	pkgtestutil "github.com/abcxyz/pkg/testutil"
 )
 
 type mockValidator struct {

--- a/pkg/justification/server_test.go
+++ b/pkg/justification/server_test.go
@@ -19,10 +19,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestExtractRequestorFromIncomingContext(t *testing.T) {

--- a/pkg/jvscrypto/cert_action_api.go
+++ b/pkg/jvscrypto/cert_action_api.go
@@ -20,6 +20,7 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
+
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 )
 

--- a/pkg/jvscrypto/cert_action_api_test.go
+++ b/pkg/jvscrypto/cert_action_api_test.go
@@ -21,17 +21,18 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
-	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/jvs/pkg/config"
-	"github.com/abcxyz/jvs/pkg/testutil"
-	"github.com/abcxyz/pkg/logging"
-	pkgtestutil "github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	jvspb "github.com/abcxyz/jvs/apis/v0"
+	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/abcxyz/jvs/pkg/testutil"
+	"github.com/abcxyz/pkg/logging"
+	pkgtestutil "github.com/abcxyz/pkg/testutil"
 )
 
 func TestCertificateAction(t *testing.T) {

--- a/pkg/jvscrypto/key_hosting_test.go
+++ b/pkg/jvscrypto/key_hosting_test.go
@@ -28,14 +28,15 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+
 	"github.com/abcxyz/jvs/pkg/config"
 	"github.com/abcxyz/jvs/pkg/testutil"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/renderer"
 	pkgtestutil "github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 )
 
 func TestGenerateJWKString(t *testing.T) {

--- a/pkg/jvscrypto/kmsutil.go
+++ b/pkg/jvscrypto/kmsutil.go
@@ -24,10 +24,11 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
-	"github.com/abcxyz/pkg/workerpool"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/abcxyz/pkg/workerpool"
 )
 
 const (

--- a/pkg/jvscrypto/rotation_handler.go
+++ b/pkg/jvscrypto/rotation_handler.go
@@ -21,14 +21,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abcxyz/jvs/pkg/config"
-	"github.com/abcxyz/pkg/logging"
-	"github.com/sethvargo/go-retry"
-	"google.golang.org/protobuf/types/known/fieldmaskpb"
-
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/sethvargo/go-retry"
 	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/abcxyz/pkg/logging"
 )
 
 // RotationHandler handles all necessary rotation actions for asymmetric keys

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -23,19 +23,19 @@ import (
 	"time"
 
 	kms "cloud.google.com/go/kms/apiv1"
-	"github.com/abcxyz/jvs/pkg/config"
-	"github.com/abcxyz/jvs/pkg/testutil"
-	"github.com/abcxyz/pkg/logging"
-	pkgtestutil "github.com/abcxyz/pkg/testutil"
-	"google.golang.org/protobuf/types/known/fieldmaskpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/abcxyz/jvs/pkg/config"
+	"github.com/abcxyz/jvs/pkg/testutil"
+	"github.com/abcxyz/pkg/logging"
+	pkgtestutil "github.com/abcxyz/pkg/testutil"
 )
 
 func TestGetKeyNameFromVersion(t *testing.T) {

--- a/pkg/plugin/plugin_manager.go
+++ b/pkg/plugin/plugin_manager.go
@@ -21,9 +21,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/hashicorp/go-plugin"
+
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 	"github.com/abcxyz/pkg/multicloser"
-	"github.com/hashicorp/go-plugin"
 )
 
 const (

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -30,12 +30,13 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
-	"github.com/abcxyz/jvs/pkg/cli"
-	"github.com/abcxyz/jvs/pkg/jvscrypto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/abcxyz/jvs/pkg/cli"
+	"github.com/abcxyz/jvs/pkg/jvscrypto"
 )
 
 // Global integration test config.


### PR DESCRIPTION
Golang-CI change is introduced to abcxyz/pkg by: https://github.com/abcxyz/pkg/pull/247