### PR TITLE
Deprecate client-lib

### DIFF
--- a/apis/v0/client.go
+++ b/apis/v0/client.go
@@ -1,0 +1,89 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v0
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+// Client allows for getting JWK keys from the JVS and validating JWTs with
+// those keys.
+type Client struct {
+	config *Config
+	keys   jwk.Set
+}
+
+// NewClient returns a JVSClient with the cache initialized.
+func NewClient(ctx context.Context, config *Config) (*Client, error) {
+	c := jwk.NewCache(ctx)
+	if err := c.Register(config.JWKSEndpoint, jwk.WithMinRefreshInterval(config.CacheTimeout)); err != nil {
+		return nil, fmt.Errorf("failed to register: %w", err)
+	}
+
+	// check that cache is correctly set up and certs are available
+	if _, err := c.Refresh(ctx, config.JWKSEndpoint); err != nil {
+		return nil, fmt.Errorf("failed to retrieve JVS public keys: %w", err)
+	}
+
+	cached := jwk.NewCachedSet(c, config.JWKSEndpoint)
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate configuration: %w", err)
+	}
+
+	return &Client{
+		config: config,
+		keys:   cached,
+	}, nil
+}
+
+// ValidateJWT takes a jwt string, converts it to a JWT, and validates the
+// signature against the keys in the JWKs endpoint.
+func (j *Client) ValidateJWT(ctx context.Context, jwtStr, expectedSubject string) (jwt.Token, error) {
+	// Handle breakglass tokens
+	token, err := ParseBreakglassToken(ctx, jwtStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse breakglass token: %w", err)
+	}
+	if token != nil {
+		if !j.config.AllowBreakglass {
+			return nil, fmt.Errorf("breakglass is forbidden, denying")
+		}
+		return token, nil
+	}
+
+	// If we got this far, the token was not breakglass, so parse as normal.
+	token, err = jwt.Parse([]byte(jwtStr),
+		jwt.WithContext(ctx),
+		jwt.WithKeySet(j.keys, jws.WithInferAlgorithmFromKey(true)),
+		jwt.WithAcceptableSkew(5*time.Second),
+		WithTypedJustifications(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify jwt: %w", err)
+	}
+
+	if got, want := token.Subject(), expectedSubject; got != want && expectedSubject != "" {
+		return nil, fmt.Errorf("subject %q does not match expected subject %q", got, want)
+	}
+
+	return token, nil
+}

--- a/apis/v0/config.go
+++ b/apis/v0/config.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v0
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sethvargo/go-envconfig"
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the jvs client configuration.
+type Config struct {
+	// JWKSEndpoint is the full path (including protocol and port) to the JWKS
+	// endpoint on a JVS server (e.g. https://jvs.corp:8080/.well-known/jwks).
+	JWKSEndpoint string `yaml:"endpoint,omitempty" env:"ENDPOINT,overwrite"`
+
+	// CacheTimeout is the duration that keys stay in cache before being revoked.
+	CacheTimeout time.Duration `yaml:"cache_timeout" env:"CACHE_TIMEOUT,overwrite,default=5m"`
+
+	// AllowBreakglass represents whether the jvs client allows breakglass.
+	AllowBreakglass bool `yaml:"allow_breakglass" env:"ALLOW_BREAKGLASS,overwrite,default=false"`
+}
+
+// Validate checks if the config is valid.
+func (cfg *Config) Validate() error {
+	var merr error
+	if cfg.JWKSEndpoint == "" {
+		merr = errors.Join(merr, fmt.Errorf("endpoint must be set"))
+	}
+	if cfg.CacheTimeout <= 0 {
+		merr = errors.Join(merr, fmt.Errorf("cache timeout must be a positive duration, got %q", cfg.CacheTimeout))
+	}
+	return merr
+}
+
+// LoadConfig calls the necessary methods to load in config using the OsLookuper
+// which finds env variables specified on the host.
+func LoadConfig(ctx context.Context, b []byte) (*Config, error) {
+	return loadConfigFromLookuper(ctx, b, envconfig.OsLookuper())
+}
+
+// loadConfigFromLooker reads in a yaml file, applies ENV config overrides from
+// the lookuper, and finally validates the config.
+func loadConfigFromLookuper(ctx context.Context, b []byte, lookuper envconfig.Lookuper) (*Config, error) {
+	var cfg Config
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse yaml: %w", err)
+	}
+
+	// Process overrides from env vars.
+	if err := envconfig.ProcessWith(ctx, &envconfig.Config{
+		Target:   &cfg,
+		Lookuper: lookuper,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to process environment variables: %w", err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("failed validating config: %w", err)
+	}
+	return &cfg, nil
+}

--- a/apis/v0/config_test.go
+++ b/apis/v0/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package v0
 
 import (
 	"bytes"
@@ -34,7 +34,7 @@ func TestLoadJVSConfig(t *testing.T) {
 		name       string
 		cfg        string
 		envs       map[string]string
-		wantConfig *JVSConfig
+		wantConfig *Config
 		wantErr    string
 	}{
 		{
@@ -45,7 +45,7 @@ endpoint: https://jvs.corp:8080/.well-known/jwks
 cache_timeout: 1m
 allow_breakglass: true
 `,
-			wantConfig: &JVSConfig{
+			wantConfig: &Config{
 				JWKSEndpoint:    "https://jvs.corp:8080/.well-known/jwks",
 				CacheTimeout:    time.Minute,
 				AllowBreakglass: true,
@@ -56,7 +56,7 @@ allow_breakglass: true
 			cfg: `
 endpoint: https://jvs.corp:8080/.well-known/jwks
 `,
-			wantConfig: &JVSConfig{
+			wantConfig: &Config{
 				JWKSEndpoint:    "https://jvs.corp:8080/.well-known/jwks",
 				CacheTimeout:    5 * time.Minute,
 				AllowBreakglass: false,
@@ -87,7 +87,7 @@ allow_breakglass: false
 				"CACHE_TIMEOUT":    "2m",
 				"ALLOW_BREAKGLASS": "true",
 			},
-			wantConfig: &JVSConfig{
+			wantConfig: &Config{
 				JWKSEndpoint:    "other.net:443",
 				CacheTimeout:    2 * time.Minute,
 				AllowBreakglass: true,
@@ -101,7 +101,7 @@ allow_breakglass: false
 			t.Parallel()
 			lookuper := envconfig.MapLookuper(tc.envs)
 			content := bytes.NewBufferString(tc.cfg).Bytes()
-			gotConfig, err := loadJVSConfigFromLookuper(ctx, content, lookuper)
+			gotConfig, err := loadConfigFromLookuper(ctx, content, lookuper)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Errorf("Unexpected err: %s", diff)
 			}

--- a/client-lib/go/client/jvs_client.go
+++ b/client-lib/go/client/jvs_client.go
@@ -12,81 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package client provides a client library for JVS
+// Package client provides a client library for JVS.
+//
+// Deprecated: Use [jvspb.Client] directly instead.
 package client
 
 import (
-	"context"
-	"fmt"
-	"time"
-
-	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/lestrrat-go/jwx/v2/jws"
-	"github.com/lestrrat-go/jwx/v2/jwt"
-
 	jvspb "github.com/abcxyz/jvs/apis/v0"
 )
 
-// JVSClient allows for getting JWK keys from the JVS and validating JWTs with
-// those keys.
-type JVSClient struct {
-	config *JVSConfig
-	keys   jwk.Set
-}
-
-// NewJVSClient returns a JVSClient with the cache initialized.
-func NewJVSClient(ctx context.Context, config *JVSConfig) (*JVSClient, error) {
-	c := jwk.NewCache(ctx)
-	if err := c.Register(config.JWKSEndpoint, jwk.WithMinRefreshInterval(config.CacheTimeout)); err != nil {
-		return nil, fmt.Errorf("failed to register: %w", err)
-	}
-
-	// check that cache is correctly set up and certs are available
-	if _, err := c.Refresh(ctx, config.JWKSEndpoint); err != nil {
-		return nil, fmt.Errorf("failed to retrieve JVS public keys: %w", err)
-	}
-
-	cached := jwk.NewCachedSet(c, config.JWKSEndpoint)
-
-	if err := config.Validate(); err != nil {
-		return nil, fmt.Errorf("failed to validate configuration: %w", err)
-	}
-
-	return &JVSClient{
-		config: config,
-		keys:   cached,
-	}, nil
-}
-
-// ValidateJWT takes a jwt string, converts it to a JWT, and validates the
-// signature against the keys in the JWKs endpoint.
-func (j *JVSClient) ValidateJWT(ctx context.Context, jwtStr, expectedSubject string) (jwt.Token, error) {
-	// Handle breakglass tokens
-	token, err := jvspb.ParseBreakglassToken(ctx, jwtStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse breakglass token: %w", err)
-	}
-	if token != nil {
-		if !j.config.AllowBreakglass {
-			return nil, fmt.Errorf("breakglass is forbidden, denying")
-		}
-		return token, nil
-	}
-
-	// If we got this far, the token was not breakglass, so parse as normal.
-	token, err = jwt.Parse([]byte(jwtStr),
-		jwt.WithContext(ctx),
-		jwt.WithKeySet(j.keys, jws.WithInferAlgorithmFromKey(true)),
-		jwt.WithAcceptableSkew(5*time.Second),
-		jvspb.WithTypedJustifications(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to verify jwt: %w", err)
-	}
-
-	if got, want := token.Subject(), expectedSubject; got != want && expectedSubject != "" {
-		return nil, fmt.Errorf("subject %q does not match expected subject %q", got, want)
-	}
-
-	return token, nil
-}
+// JVSClient is the underlying client. This is an alias for jvspb.
+//
+// Deprecated: Use [jvspb.Client] directly instead.
+type JVSClient = jvspb.Client

--- a/client-lib/go/client/jvs_config.go
+++ b/client-lib/go/client/jvs_config.go
@@ -15,61 +15,16 @@
 package client
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"time"
-
-	"github.com/sethvargo/go-envconfig"
-	"gopkg.in/yaml.v3"
+	jvspb "github.com/abcxyz/jvs/apis/v0"
 )
 
-// JVSConfig is the jvs client configuration.
-type JVSConfig struct {
-	// JWKSEndpoint is the full path (including protocol and port) to the JWKS
-	// endpoint on a JVS server (e.g. https://jvs.corp:8080/.well-known/jwks).
-	JWKSEndpoint string `yaml:"endpoint,omitempty" env:"ENDPOINT,overwrite"`
+// JVSConfig is the config. This is an alias for jvspb.
+//
+// Deprecated: Use [jvspb.Config] directly instead.
+type JVSConfig = jvspb.Config
 
-	// CacheTimeout is the duration that keys stay in cache before being revoked.
-	CacheTimeout time.Duration `yaml:"cache_timeout" env:"CACHE_TIMEOUT,overwrite,default=5m"`
-
-	// AllowBreakglass represents whether the jvs client allows breakglass.
-	AllowBreakglass bool `yaml:"allow_breakglass" env:"ALLOW_BREAKGLASS,overwrite,default=false"`
-}
-
-// Validate checks if the config is valid.
-func (cfg *JVSConfig) Validate() (merr error) {
-	if cfg.JWKSEndpoint == "" {
-		merr = errors.Join(merr, fmt.Errorf("endpoint must be set"))
-	}
-	if cfg.CacheTimeout <= 0 {
-		merr = errors.Join(merr, fmt.Errorf("cache timeout must be a positive duration, got %q", cfg.CacheTimeout))
-	}
-	return
-}
-
-// LoadJVSConfig calls the necessary methods to load in config using the OsLookuper which finds env variables specified on the host.
-func LoadJVSConfig(ctx context.Context, b []byte) (*JVSConfig, error) {
-	return loadJVSConfigFromLookuper(ctx, b, envconfig.OsLookuper())
-}
-
-// loadConfigFromLooker reads in a yaml file, applies ENV config overrides from the lookuper, and finally validates the config.
-func loadJVSConfigFromLookuper(ctx context.Context, b []byte, lookuper envconfig.Lookuper) (*JVSConfig, error) {
-	var cfg JVSConfig
-	if err := yaml.Unmarshal(b, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse yaml: %w", err)
-	}
-
-	// Process overrides from env vars.
-	if err := envconfig.ProcessWith(ctx, &envconfig.Config{
-		Target:   &cfg,
-		Lookuper: lookuper,
-	}); err != nil {
-		return nil, fmt.Errorf("failed to process environment variables: %w", err)
-	}
-
-	if err := cfg.Validate(); err != nil {
-		return nil, fmt.Errorf("failed validating config: %w", err)
-	}
-	return &cfg, nil
-}
+// LoadJVSConfig calls the necessary methods to load in config using the
+// OsLookuper which finds env variables specified on the host.
+//
+// Deprecated: Use [jvspb.LoadConfig] directly instead.
+var LoadJVSConfig = jvspb.LoadConfig

--- a/pkg/cli/token_validate.go
+++ b/pkg/cli/token_validate.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	jvspb "github.com/abcxyz/jvs/apis/v0"
-	"github.com/abcxyz/jvs/client-lib/go/client"
 	"github.com/abcxyz/jvs/pkg/formatter"
 	"github.com/abcxyz/pkg/cli"
 )
@@ -153,7 +152,7 @@ func (c *TokenValidateCommand) Run(ctx context.Context, args []string) error {
 	if token != nil {
 		breakglass = true
 	} else {
-		jvsclient, err := client.NewJVSClient(ctx, &client.JVSConfig{
+		jvsclient, err := jvspb.NewClient(ctx, &jvspb.Config{
 			JWKSEndpoint:    c.flagJWKSEndpoint,
 			CacheTimeout:    cacheTimeout,
 			AllowBreakglass: true,


### PR DESCRIPTION
This removes the client-lib package and embeds the functionality directly into the generated protos. Originally, there was a goal of releasing the client independently from the server, but that proved to be complex and unnecessary. We undid that change, but kept the client separate.

This moves the logic into the generated protos where they belong, but maintains compatibility by aliasing the types and functions inside client-lib.