### PR TITLE
Update to cloud run module that ignores `status` field

### DIFF
--- a/terraform/modules/jvs-services/cert-rotator.tf
+++ b/terraform/modules/jvs-services/cert-rotator.tf
@@ -24,7 +24,7 @@ resource "google_project_service" "services" {
 }
 
 module "cert_rotator_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=580de3cc99dce5f37f7698b14e04fdd1c86ab15a"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
 
   project_id = var.project_id
 

--- a/terraform/modules/jvs-services/jvs-api.tf
+++ b/terraform/modules/jvs-services/jvs-api.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "api_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=580de3cc99dce5f37f7698b14e04fdd1c86ab15a"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
 
   project_id = var.project_id
 

--- a/terraform/modules/jvs-services/jvs-ui.tf
+++ b/terraform/modules/jvs-services/jvs-ui.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "ui_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=580de3cc99dce5f37f7698b14e04fdd1c86ab15a"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
 
   project_id = var.project_id
 

--- a/terraform/modules/jvs-services/public-key.tf
+++ b/terraform/modules/jvs-services/public-key.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "public_key_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=580de3cc99dce5f37f7698b14e04fdd1c86ab15a"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
 
   project_id = var.project_id
 


### PR DESCRIPTION
This prevents spurious diffs from appearing in infra-gcp.