### PR TITLE
Update to cloud run module that ignores the "sha" label

### DIFF
--- a/terraform/modules/jvs-services/jvs-api.tf
+++ b/terraform/modules/jvs-services/jvs-api.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "api_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=e8499c7bbc397decd59f5d3c59fc55bcf6704b29"
 
   project_id = var.project_id
 


### PR DESCRIPTION
This just includes https://github.com/abcxyz/terraform-modules/pull/56 and https://github.com/abcxyz/terraform-modules/pull/55, to ignore "sha" and un-ignore "status".