### PR TITLE
Update to the latest cloud run terraform module

### DIFF
--- a/terraform/modules/jvs-services/cert-rotator.tf
+++ b/terraform/modules/jvs-services/cert-rotator.tf
@@ -24,7 +24,7 @@ resource "google_project_service" "services" {
 }
 
 module "cert_rotator_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=9fad03b2de747c111717064a584132f9bdd218b5"
 
   project_id = var.project_id
 

--- a/terraform/modules/jvs-services/jvs-api.tf
+++ b/terraform/modules/jvs-services/jvs-api.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "api_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=e8499c7bbc397decd59f5d3c59fc55bcf6704b29"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=9fad03b2de747c111717064a584132f9bdd218b5"
 
   project_id = var.project_id
 

--- a/terraform/modules/jvs-services/jvs-ui.tf
+++ b/terraform/modules/jvs-services/jvs-ui.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "ui_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=9fad03b2de747c111717064a584132f9bdd218b5"
 
   project_id = var.project_id
 

--- a/terraform/modules/jvs-services/public-key.tf
+++ b/terraform/modules/jvs-services/public-key.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "public_key_cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=7ecb6d41328ce8b6b5862d8c577825675a602fdc"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=9fad03b2de747c111717064a584132f9bdd218b5"
 
   project_id = var.project_id
 


### PR DESCRIPTION
Third time's the charm; trying to ignore the `sha` label on deployed cloud run services.