### PR TITLE
Bump terraform

### DIFF
--- a/terraform/e2e/gclb.tf
+++ b/terraform/e2e/gclb.tf
@@ -192,6 +192,7 @@ resource "google_compute_backend_service" "jvs_ui_backend" {
   }
 
   iap {
+    enabled              = true
     oauth2_client_id     = google_iap_client.project_client.client_id
     oauth2_client_secret = google_iap_client.project_client.secret
   }


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/guides/version_6_upgrade#iapenabled-is-now-required-in-the-iap-block