### PR TITLE
Remove shadowed loop variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     uses: 'abcxyz/pkg/.github/workflows/java-lint.yml@main' # ratchet:exclude
     with:
       java_version: '11'
+      google_java_format_version: '1.18.1'
+      java_distribution: 'adopt'
 
   go-test:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main' # ratchet:exclude

--- a/apis/v0/breakglass_test.go
+++ b/apis/v0/breakglass_test.go
@@ -49,8 +49,6 @@ func TestCreateBreakglassToken(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -140,8 +138,6 @@ func TestParseBreakglassToken(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/apis/v0/client_test.go
+++ b/apis/v0/client_test.go
@@ -147,8 +147,6 @@ func TestValidateJWT(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/apis/v0/config_test.go
+++ b/apis/v0/config_test.go
@@ -96,7 +96,6 @@ allow_breakglass: false
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			lookuper := envconfig.MapLookuper(tc.envs)

--- a/apis/v0/jwt_test.go
+++ b/apis/v0/jwt_test.go
@@ -65,8 +65,6 @@ func TestGetRequestor(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -115,8 +113,6 @@ func TestSetRequestor(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -170,8 +166,6 @@ func TestClearRequestor(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -301,8 +295,6 @@ func TestGetJustifications(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -363,8 +355,6 @@ func TestSetJustifications(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -422,8 +412,6 @@ func TestClearJustifications(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/apis/v0/plugin_test.go
+++ b/apis/v0/plugin_test.go
@@ -57,8 +57,6 @@ func TestExplanationValidator(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -93,8 +91,6 @@ func TestGetUIDataInValidator(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/api_server_test.go
+++ b/pkg/cli/api_server_test.go
@@ -61,8 +61,6 @@ func TestAPIServerCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/public_key_server_test.go
+++ b/pkg/cli/public_key_server_test.go
@@ -61,8 +61,6 @@ func TestPublicKeyServerCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/rotation_server_test.go
+++ b/pkg/cli/rotation_server_test.go
@@ -62,8 +62,6 @@ func TestRotationServerCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/token_create_test.go
+++ b/pkg/cli/token_create_test.go
@@ -167,8 +167,6 @@ func TestTokenCreateCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/token_validate_test.go
+++ b/pkg/cli/token_validate_test.go
@@ -257,8 +257,6 @@ claims:
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/cli/ui_server_test.go
+++ b/pkg/cli/ui_server_test.go
@@ -63,8 +63,6 @@ func TestUIServerCommand(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/cert_rotation_config_test.go
+++ b/pkg/config/cert_rotation_config_test.go
@@ -68,8 +68,6 @@ func TestCertRotationConfig_ToFlags(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -198,8 +196,6 @@ func TestCertRotationConfig_Validate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/justification_config.go
+++ b/pkg/config/justification_config.go
@@ -72,9 +72,9 @@ func (cfg *JustificationConfig) Validate() (merr error) {
 			got))
 	}
 
-	if def, max := cfg.DefaultTTL, cfg.MaxTTL; def > max {
+	if def, maximum := cfg.DefaultTTL, cfg.MaxTTL; def > maximum {
 		merr = errors.Join(merr, fmt.Errorf("default ttl (%s) must be less than or equal to the max ttl (%s)",
-			timeutil.HumanDuration(def), timeutil.HumanDuration(max)))
+			timeutil.HumanDuration(def), timeutil.HumanDuration(maximum)))
 	}
 
 	return

--- a/pkg/config/justification_config_test.go
+++ b/pkg/config/justification_config_test.go
@@ -71,8 +71,6 @@ func TestJustificationConfig_ToFlags(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -180,8 +178,6 @@ func TestJustificationConfig_Validate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/public_key_config_test.go
+++ b/pkg/config/public_key_config_test.go
@@ -59,8 +59,6 @@ func TestPublicKeyConfig_ToFlags(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -125,8 +123,6 @@ func TestPublicKeyConfig_Validate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/ui_config_test.go
+++ b/pkg/config/ui_config_test.go
@@ -77,8 +77,6 @@ func TestUIServiceConfig_ToFlags(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,8 +153,6 @@ func TestUIServiceConfig_Validate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -100,8 +100,6 @@ func TestHandlePopup(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -211,8 +209,6 @@ func TestValidateOrigin(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -263,8 +259,6 @@ func TestValidateLocalIp(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -359,8 +353,6 @@ func TestValidateForm(t *testing.T) {
 	cases = append(cases, sadPathCases...)
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -408,8 +400,6 @@ func TestIsValidOneOf(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -448,8 +438,6 @@ func TestGetEmail(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -537,8 +525,6 @@ func TestGetCatagoriesDisplayData(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/idtoken/idtoken_test.go
+++ b/pkg/idtoken/idtoken_test.go
@@ -80,7 +80,6 @@ func TestIDTokenFromDefaultTokenSource(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ts := &tokenSource{tokenSource: tc.ts}

--- a/pkg/justification/processor.go
+++ b/pkg/justification/processor.go
@@ -184,18 +184,18 @@ func (p *Processor) runValidations(ctx context.Context, req *jvspb.CreateJustifi
 
 	// This isn't perfect, but it's the easiest place to get "close" to limiting
 	// the size.
-	if got, max := justificationsLength, 4_000; got > max {
+	if got, maximum := justificationsLength, 4_000; got > maximum {
 		validationErr = errors.Join(validationErr, fmt.Errorf("justification size (%d bytes) must be less than %d bytes",
-			got, max))
+			got, maximum))
 	}
 
 	var audiencesLength int
 	for _, v := range req.GetAudiences() {
 		audiencesLength += len(v)
 	}
-	if got, max := audiencesLength, 1_000; got > max {
+	if got, maximum := audiencesLength, 1_000; got > maximum {
 		validationErr = errors.Join(validationErr, fmt.Errorf("audiences size (%d bytes) must be less than %d bytes",
-			got, max))
+			got, maximum))
 	}
 
 	// In case of internal errors, a standard internal error message will be shown to the user,
@@ -268,14 +268,14 @@ func (p *Processor) createToken(ctx context.Context, requestor string, req *jvsp
 // default TTL, and maximum configured TTL. If the requested TTL is greater than
 // the maximum TTL, it returns an error. If the requested TTL is 0, it returns
 // the default TTL.
-func computeTTL(req, def, max time.Duration) (time.Duration, error) {
+func computeTTL(req, def, maximum time.Duration) (time.Duration, error) {
 	if req <= 0 {
 		return def, nil
 	}
 
-	if req > max {
+	if req > maximum {
 		return 0, fmt.Errorf("requested ttl (%s) cannot be greater than max tll (%s)",
-			timeutil.HumanDuration(req), timeutil.HumanDuration(max))
+			timeutil.HumanDuration(req), timeutil.HumanDuration(maximum))
 	}
 
 	return req, nil

--- a/pkg/justification/processor_test.go
+++ b/pkg/justification/processor_test.go
@@ -390,8 +390,6 @@ func TestCreateToken(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -587,8 +585,6 @@ func TestComputeTTL(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/justification/server_test.go
+++ b/pkg/justification/server_test.go
@@ -85,8 +85,6 @@ func TestExtractRequestorFromIncomingContext(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/jvscrypto/cert_action_api_test.go
+++ b/pkg/jvscrypto/cert_action_api_test.go
@@ -316,8 +316,6 @@ func TestCertificateAction(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/jvscrypto/key_hosting_test.go
+++ b/pkg/jvscrypto/key_hosting_test.go
@@ -91,8 +91,6 @@ func TestGenerateJWKString(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/jvscrypto/rotation_handler_test.go
+++ b/pkg/jvscrypto/rotation_handler_test.go
@@ -67,7 +67,6 @@ func TestGetKeyNameFromVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			output, err := getKeyNameFromVersion(tc.input)
@@ -274,7 +273,6 @@ func TestDetermineActions(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -464,8 +462,6 @@ func TestPerformActions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/test/integ/main_test.go
+++ b/test/integ/main_test.go
@@ -138,7 +138,6 @@ func TestAPIAndPublicKeyService(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This is no longer required as of Go 1.22+
